### PR TITLE
Dont log the full user list to console on meeting series edit

### DIFF
--- a/client/templates/meetingseries/meetingSeriesEditUsersHelpers.js
+++ b/client/templates/meetingseries/meetingSeriesEditUsersHelpers.js
@@ -28,7 +28,7 @@ export var userlistClean = function (allUsers,substractUsers) {
             longName2shortName[aUser["username"]+longname] = aUser["username"];
         }
     }
-    console.log(longName2shortName);
+
     return resultUsers;
 };
 


### PR DESCRIPTION
On the meeting series edit, the full user list is logged to the
javascript console. This does not seem necessary.