### PR TITLE
Feature/#211 user gets email on role change

### DIFF
--- a/client/templates/meetingseries/meetingSeriesEdit.html
+++ b/client/templates/meetingseries/meetingSeriesEdit.html
@@ -54,8 +54,8 @@
                                         <div class="panel-body">
                                             {{>meetingSeriesEditUsers userEditConfig}}
                                             <div class="checkbox" id="id_roleChange">
-                                                <label>
-                                                    <input type="checkbox" class="checkbox" id="btnRoleChange" checked>
+                                                <label id="labelRoleChange">
+                                                    <input type="checkbox" class="checkbox" checked id="checkBoxRoleChange">
                                                     <span>Notify participants on role change</span>
                                                 </label>
                                             </div>

--- a/client/templates/meetingseries/meetingSeriesEdit.html
+++ b/client/templates/meetingseries/meetingSeriesEdit.html
@@ -53,6 +53,12 @@
                                     <div id="collapseTwo" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
                                         <div class="panel-body">
                                             {{>meetingSeriesEditUsers userEditConfig}}
+                                            <div class="checkbox" id="id_roleChange">
+                                                <label>
+                                                    <input type="checkbox" class="checkbox" id="btnRoleChange" checked>
+                                                    <span>Notify participants on role change</span>
+                                                </label>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/client/templates/meetingseries/meetingSeriesEdit.js
+++ b/client/templates/meetingseries/meetingSeriesEdit.js
@@ -161,7 +161,6 @@ Template.meetingSeriesEdit.events({
                 if(matchingUser === undefined) {
                     let mailer = new RoleChangeMailHandler(oldUserWithRole.getUser()._id, oldUserRole, undefined, Meteor.user(), meetingSeriesId);
                     mailer.send();
-                    break;
                 } else {
                     let index = usersWithRolesAfterEditForEmails.indexOf(matchingUser);
                     let newUserWithRole = new UserRoles(matchingUser._idOrg);
@@ -174,7 +173,6 @@ Template.meetingSeriesEdit.events({
                     usersWithRolesAfterEditForEmails.splice(index, 1);
                 }
             }
-            console.log("Remaining Users -> newly added")
             for(let i in usersWithRolesAfterEditForEmails){
                 console.log(usersWithRolesAfterEditForEmails[i]);
                 let newUser = usersWithRolesAfterEditForEmails[i];
@@ -183,6 +181,8 @@ Template.meetingSeriesEdit.events({
                 mailer.send();
             }
         }
+
+        console.log(usersWithRolesAfterEdit);
 
         for (let i in usersWithRolesAfterEdit) {
             let usrAfterEdit = usersWithRolesAfterEdit[i];

--- a/client/templates/meetingseries/meetingSeriesEdit.js
+++ b/client/templates/meetingseries/meetingSeriesEdit.js
@@ -154,10 +154,12 @@ Template.meetingSeriesEdit.events({
                 let oldUserId = usersBeforeEdit[i];
                 let oldUserWithRole = new UserRoles(oldUserId);
                 let oldUserRole = oldUserWithRole.currentRoleFor(meetingSeriesId);
+                // Search in after edit users whether the users still exists
                 let matchingUser = usersWithRolesAfterEditForEmails.find( function (user) {
                     return oldUserWithRole._userId === user._idOrg;
                 });
 
+                // If he does not, his role was removed
                 if(matchingUser === undefined) {
                     let mailer = new RoleChangeMailHandler(oldUserWithRole.getUser()._id, oldUserRole, undefined, Meteor.user(), meetingSeriesId);
                     mailer.send();
@@ -166,6 +168,7 @@ Template.meetingSeriesEdit.events({
                     let newUserWithRole = new UserRoles(matchingUser._idOrg);
                     let newUserRole = matchingUser.roles[meetingSeriesId][0];
 
+                    // Roles have changed
                     if(newUserRole !== oldUserRole) {
                         let mailer = new RoleChangeMailHandler(newUserWithRole.getUser()._id, oldUserRole, newUserRole, Meteor.user(), meetingSeriesId);
                         mailer.send();
@@ -173,16 +176,14 @@ Template.meetingSeriesEdit.events({
                     usersWithRolesAfterEditForEmails.splice(index, 1);
                 }
             }
+            // The remaining users in the after-edit-array -> got added
             for(let i in usersWithRolesAfterEditForEmails){
-                console.log(usersWithRolesAfterEditForEmails[i]);
                 let newUser = usersWithRolesAfterEditForEmails[i];
                 let newUserRole = newUser.roles[meetingSeriesId][0];
                 let mailer = new RoleChangeMailHandler(newUser._idOrg, undefined, newUserRole, Meteor.user(), meetingSeriesId);
                 mailer.send();
             }
         }
-
-        console.log(usersWithRolesAfterEdit);
 
         for (let i in usersWithRolesAfterEdit) {
             let usrAfterEdit = usersWithRolesAfterEdit[i];

--- a/client/templates/meetingseries/meetingSeriesEdit.js
+++ b/client/templates/meetingseries/meetingSeriesEdit.js
@@ -121,7 +121,7 @@ Template.meetingSeriesEdit.events({
 
         let aProject = tmpl.find('#id_meetingproject').value;
         let aName = tmpl.find('#id_meetingname').value;
-        let notifyOnRoleChange = tmpl.find("#btnRoleChange").checked;
+        let notifyOnRoleChange = tmpl.find("#checkBoxRoleChange").checked;
 
         // validate form and show errors - necessary for browsers which do not support form-validation
         let projectNode = tmpl.$('#id_meetingproject');

--- a/imports/collections/meetingseries_private.js
+++ b/imports/collections/meetingseries_private.js
@@ -4,6 +4,9 @@ import { Roles } from 'meteor/alanning:roles';
 import { UserRoles } from './../userroles';
 import { GlobalSettings } from '../config/GlobalSettings';
 import { formatDateISO8601 } from '/imports/helpers/date';
+import {MeetingSeries} from "../meetingseries";
+import {RoleChangeMailHandler} from "../mail/RoleChangeMailHandler";
+import {UserRoles as userroles} from "../userroles";
 
 if (Meteor.isServer) {
     Meteor.publish('meetingSeries', function meetingSeriesPublication() {
@@ -104,6 +107,29 @@ Meteor.methods({
                 console.error(e);
                 throw new Meteor.Error('runtime-error', 'Error updating meeting series collection', e);
             }
+        }
+    },
+
+    'meetingseries.sendRoleChange'(userId, oldRole, newRole, meetingSeriesId) {
+        // Make sure the user is logged in before trying to send mails
+        if (!Meteor.userId()) {
+            throw new Meteor.Error('not-authorized');
+        }
+
+        // Ensure user is Moderator of the meeting series
+        let userRole = new UserRoles(Meteor.userId());
+        if(userRole.isModeratorOf(meetingSeriesId)){
+            if (!GlobalSettings.isEMailDeliveryEnabled()) {
+                console.log('Skip sending mails because email delivery is not enabled. To enable email delivery set enableMailDelivery to true in your settings.json file');
+                throw new Meteor.Error('Cannot send agenda', 'Email delivery is not enabled in your 4minitz installation.');
+            }
+
+            if(Meteor.isServer) {
+                let roleChangeMailHandler = new RoleChangeMailHandler(userId, oldRole, newRole, Meteor.user(), meetingSeriesId);
+                roleChangeMailHandler.send();
+            }
+        } else {
+            throw new Meteor.Error('Cannot send E-Mails for role change', 'You are not a moderator of the meeting series.');
         }
     }
 });

--- a/imports/collections/meetingseries_private.js
+++ b/imports/collections/meetingseries_private.js
@@ -121,7 +121,7 @@ Meteor.methods({
         if(userRole.isModeratorOf(meetingSeriesId)){
             if (!GlobalSettings.isEMailDeliveryEnabled()) {
                 console.log('Skip sending mails because email delivery is not enabled. To enable email delivery set enableMailDelivery to true in your settings.json file');
-                throw new Meteor.Error('Cannot send agenda', 'Email delivery is not enabled in your 4minitz installation.');
+                throw new Meteor.Error('Cannot send role change mail', 'Email delivery is not enabled in your 4minitz installation.');
             }
 
             if(Meteor.isServer) {

--- a/imports/mail/RoleChangeMailHandler.js
+++ b/imports/mail/RoleChangeMailHandler.js
@@ -71,7 +71,7 @@ export class RoleChangeMailHandler {
 
             mailer.send();
         } else {
-            console.error("Could not send admin register mail. User has no mail address: "+this._user._id);
+            console.error("Could not send role change mail. User has no mail address: "+this._user._id);
         }
     }
 }

--- a/imports/mail/RoleChangeMailHandler.js
+++ b/imports/mail/RoleChangeMailHandler.js
@@ -7,7 +7,7 @@ import { MailFactory } from './MailFactory'
 import { GlobalSettings } from '../config/GlobalSettings'
 import {UserRoles as userroles} from "../userroles";
 
-export class RoleChangedMailHandler {
+export class RoleChangeMailHandler {
     constructor(userId, oldRole, newRole, moderator, meetingSeriesId) {
         this._oldRole = oldRole;
         this._newRole = newRole;
@@ -28,19 +28,25 @@ export class RoleChangedMailHandler {
 
         let emailTo = this._user.emails[0].address;
 
-        //console.log(adminFrom);
-        //console.log(emailTo);
-        let oldUserRole = userroles.role2Text(this._oldRole);
-        let newUserRole = userroles.role2Text(this._newRole[0]);
 
-        if(oldUserRole === undefined)
+        let oldUserRole;
+        let newUserRole;
+        if(this._oldRole === undefined) {
             oldUserRole = "None";
-        if(newUserRole === undefined)
-            newUserRole = "None"
+        } else {
+            oldUserRole = userroles.role2Text(this._oldRole);
+        }
+
+        if(this._newRole === undefined) {
+            newUserRole = "None";
+        } else {
+            newUserRole = userroles.role2Text(this._newRole);
+        }
 
         let name = "";
+        //console.log(this._user);
         if(this._user.profile === undefined) {
-            name = "NO PROFILE FOUND";
+            name = this._user.username;
         }
         else {
             name =  this._user.profile.name;
@@ -52,14 +58,14 @@ export class RoleChangedMailHandler {
             "Your new role is           : " +  newUserRole + "\n"+
             "The change was performed by: " + this._moderator.username + "\n"  +
             "\n" +
-            '        Your Admin.\n' +
+            'Your Admin.\n' +
             "\n" +
             "\n" +
             "--- \n" +
             "4Minitz is free open source developed by the 4Minitz team.\n" +
             "Source is available at https://github.com/4minitz/4minitz\n");
 
-
+        /*
         if (this._user.emails && this._user.emails.length > 0) {
             let mailer = MailFactory.getMailer(adminFrom, emailTo);
             mailer.setSubject("Your role changed");
@@ -82,5 +88,6 @@ export class RoleChangedMailHandler {
         } else {
             console.error("Could not send admin register mail. User has no mail address: "+this._user._id);
         }
+        */
     }
 }

--- a/imports/mail/RoleChangeMailHandler.js
+++ b/imports/mail/RoleChangeMailHandler.js
@@ -20,29 +20,13 @@ export class RoleChangeMailHandler {
     }
 
     send() {
-        let emailFrom = Meteor.user().emails;
-        emailFrom = this._moderator.emails;
+        let emailFrom = this._moderator.emails;
         let adminFrom = (emailFrom && emailFrom.length > 0)
             ? emailFrom[0].address
             : GlobalSettings.getDefaultEmailSenderAddress();
-
         let emailTo = this._user.emails[0].address;
 
-
-        let oldUserRole;
-        let newUserRole;
-        if(this._oldRole === undefined) {
-            oldUserRole = "None";
-        } else {
-            oldUserRole = userroles.role2Text(this._oldRole);
-        }
-
-        if(this._newRole === undefined) {
-            newUserRole = "None";
-        } else {
-            newUserRole = userroles.role2Text(this._newRole);
-        }
-
+        // set parameter
         let name = "";
         if(this._user.profile === undefined) {
             name = this._user.username;
@@ -51,12 +35,20 @@ export class RoleChangeMailHandler {
             name =  this._user.profile.name;
         }
 
-        console.log("Hello " + name + ", \n"+
-            "Your role in this Meeting changed: " + GlobalSettings.getRootUrl("meetingseries/" + this._meetingSeriesId) + "\n"+
-            "Your old role was          : " +  oldUserRole + "\n"+
-            "Your new role is           : " +  newUserRole + "\n"+
-            "The change was performed by: " + this._moderator.username);
+        if(this._oldRole == undefined) {
+            this._oldRole = "None";
+        } else {
+            this._oldRole = userroles.role2Text(this._oldRole);
+        }
 
+        if(this._newRole == undefined) {
+            this._newRole = "None";
+        } else {
+            this._newRole = userroles.role2Text(this._newRole);
+        }
+
+
+        // generate mail
         if (this._user.emails && this._user.emails.length > 0) {
             let mailer = MailFactory.getMailer(adminFrom, emailTo);
             mailer.setSubject("Your role changed");
@@ -64,11 +56,10 @@ export class RoleChangeMailHandler {
                 "Your role in this Meeting changed: " + GlobalSettings.getRootUrl("meetingseries/" + this._meetingSeriesId) + "\n"+
                 "Your old role was          : " + this._oldRole + "\n"+
                 "Your new role is           : " + this._newRole + "\n"+
-                "The change was performed by: " + this._moderator + "\n"  +
+                "The change was performed by: " + this._moderator.username + "\n"  +
 
                 "\n" +
                 "Your Admin.\n" +
-                "\n" +
                 "\n" +
                 "--- \n" +
                 "4Minitz is free open source developed by the 4Minitz team.\n" +

--- a/imports/mail/RoleChangeMailHandler.js
+++ b/imports/mail/RoleChangeMailHandler.js
@@ -22,7 +22,7 @@ export class RoleChangeMailHandler {
 
     send() {
         let emailFrom = this._moderator.emails;
-        let adminFrom = (emailFrom && emailFrom.length > 0)
+        let modFrom = (emailFrom && emailFrom.length > 0)
             ? emailFrom[0].address
             : GlobalSettings.getDefaultEmailSenderAddress();
         let emailTo = this._user.emails[0].address;
@@ -53,12 +53,12 @@ export class RoleChangeMailHandler {
 
         // generate mail
         if (this._user.emails && this._user.emails.length > 0) {
-            let mailer = MailFactory.getMailer(adminFrom, emailTo);
+            let mailer = MailFactory.getMailer(modFrom, emailTo);
             mailer.setSubject("Your role changed");
             mailer.setText("Hello " + userName + ", \n"+
-                "Your was changed in the meeting series \"" + meetingName + "\" (" + GlobalSettings.getRootUrl("meetingseries/" + this._meetingSeriesId) + ")\n"+
-                "Your old role was\t\t : " + this._oldRole + "\n"+
-                "Your new role is\t\t : " + this._newRole + "\n"+
+                "Your role was changed in the meeting series \"" + meetingName + "\" (" + GlobalSettings.getRootUrl("meetingseries/" + this._meetingSeriesId) + ")\n"+
+                "Your old role was           : " + this._oldRole + "\n"+
+                "Your new role is            : " + this._newRole + "\n"+
                 "The change was performed by : " + this._moderator.username + "\n"  +
 
                 "\n" +

--- a/imports/mail/RoleChangeMailHandler.js
+++ b/imports/mail/RoleChangeMailHandler.js
@@ -44,7 +44,6 @@ export class RoleChangeMailHandler {
         }
 
         let name = "";
-        //console.log(this._user);
         if(this._user.profile === undefined) {
             name = this._user.username;
         }
@@ -56,16 +55,8 @@ export class RoleChangeMailHandler {
             "Your role in this Meeting changed: " + GlobalSettings.getRootUrl("meetingseries/" + this._meetingSeriesId) + "\n"+
             "Your old role was          : " +  oldUserRole + "\n"+
             "Your new role is           : " +  newUserRole + "\n"+
-            "The change was performed by: " + this._moderator.username + "\n"  +
-            "\n" +
-            'Your Admin.\n' +
-            "\n" +
-            "\n" +
-            "--- \n" +
-            "4Minitz is free open source developed by the 4Minitz team.\n" +
-            "Source is available at https://github.com/4minitz/4minitz\n");
+            "The change was performed by: " + this._moderator.username);
 
-        /*
         if (this._user.emails && this._user.emails.length > 0) {
             let mailer = MailFactory.getMailer(adminFrom, emailTo);
             mailer.setSubject("Your role changed");
@@ -76,7 +67,7 @@ export class RoleChangeMailHandler {
                 "The change was performed by: " + this._moderator + "\n"  +
 
                 "\n" +
-                "        Your Admin.\n" +
+                "Your Admin.\n" +
                 "\n" +
                 "\n" +
                 "--- \n" +
@@ -88,6 +79,5 @@ export class RoleChangeMailHandler {
         } else {
             console.error("Could not send admin register mail. User has no mail address: "+this._user._id);
         }
-        */
     }
 }

--- a/imports/mail/RoleChangeMailHandler.js
+++ b/imports/mail/RoleChangeMailHandler.js
@@ -71,7 +71,7 @@ export class RoleChangeMailHandler {
 
             mailer.send();
         } else {
-            console.error("Could not send role change mail. User has no mail address: "+this._user._id);
+            console.error("Could not send eMail for role change. User has no mail address: "+this._user._id);
         }
     }
 }

--- a/imports/mail/RoleChangeMailHandler.js
+++ b/imports/mail/RoleChangeMailHandler.js
@@ -1,0 +1,86 @@
+/**
+ * Created by Simon on 25.05.2017.
+ */
+import { Meteor } from 'meteor/meteor';
+
+import { MailFactory } from './MailFactory'
+import { GlobalSettings } from '../config/GlobalSettings'
+import {UserRoles as userroles} from "../userroles";
+
+export class RoleChangedMailHandler {
+    constructor(userId, oldRole, newRole, moderator, meetingSeriesId) {
+        this._oldRole = oldRole;
+        this._newRole = newRole;
+        this._moderator = moderator;
+        this._meetingSeriesId = meetingSeriesId;
+        this._user = Meteor.users.findOne(userId);
+        if (!this._user) {
+            throw new Meteor.Error("Send Role Change Mail", "Could not find user: "+ userId);
+        }
+    }
+
+    send() {
+        let emailFrom = Meteor.user().emails;
+        emailFrom = this._moderator.emails;
+        let adminFrom = (emailFrom && emailFrom.length > 0)
+            ? emailFrom[0].address
+            : GlobalSettings.getDefaultEmailSenderAddress();
+
+        let emailTo = this._user.emails[0].address;
+
+        //console.log(adminFrom);
+        //console.log(emailTo);
+        let oldUserRole = userroles.role2Text(this._oldRole);
+        let newUserRole = userroles.role2Text(this._newRole[0]);
+
+        if(oldUserRole === undefined)
+            oldUserRole = "None";
+        if(newUserRole === undefined)
+            newUserRole = "None"
+
+        let name = "";
+        if(this._user.profile === undefined) {
+            name = "NO PROFILE FOUND";
+        }
+        else {
+            name =  this._user.profile.name;
+        }
+
+        console.log("Hello " + name + ", \n"+
+            "Your role in this Meeting changed: " + GlobalSettings.getRootUrl("meetingseries/" + this._meetingSeriesId) + "\n"+
+            "Your old role was          : " +  oldUserRole + "\n"+
+            "Your new role is           : " +  newUserRole + "\n"+
+            "The change was performed by: " + this._moderator.username + "\n"  +
+            "\n" +
+            '        Your Admin.\n' +
+            "\n" +
+            "\n" +
+            "--- \n" +
+            "4Minitz is free open source developed by the 4Minitz team.\n" +
+            "Source is available at https://github.com/4minitz/4minitz\n");
+
+
+        if (this._user.emails && this._user.emails.length > 0) {
+            let mailer = MailFactory.getMailer(adminFrom, emailTo);
+            mailer.setSubject("Your role changed");
+            mailer.setText("Hello " + name + ", \n"+
+                "Your role in this Meeting changed: " + GlobalSettings.getRootUrl("meetingseries/" + this._meetingSeriesId) + "\n"+
+                "Your old role was          : " + this._oldRole + "\n"+
+                "Your new role is           : " + this._newRole + "\n"+
+                "The change was performed by: " + this._moderator + "\n"  +
+
+                "\n" +
+                "        Your Admin.\n" +
+                "\n" +
+                "\n" +
+                "--- \n" +
+                "4Minitz is free open source developed by the 4Minitz team.\n" +
+                "Source is available at https://github.com/4minitz/4minitz\n"
+            );
+
+            mailer.send();
+        } else {
+            console.error("Could not send admin register mail. User has no mail address: "+this._user._id);
+        }
+    }
+}

--- a/imports/mail/RoleChangeMailHandler.js
+++ b/imports/mail/RoleChangeMailHandler.js
@@ -6,6 +6,7 @@ import { Meteor } from 'meteor/meteor';
 import { MailFactory } from './MailFactory'
 import { GlobalSettings } from '../config/GlobalSettings'
 import {UserRoles as userroles} from "../userroles";
+import {MeetingSeries} from "../meetingseries";
 
 export class RoleChangeMailHandler {
     constructor(userId, oldRole, newRole, moderator, meetingSeriesId) {
@@ -27,12 +28,14 @@ export class RoleChangeMailHandler {
         let emailTo = this._user.emails[0].address;
 
         // set parameter
-        let name = "";
+        let meetingSeries = new MeetingSeries(this._meetingSeriesId)
+        let meetingName = meetingSeries.name;
+
+        let userName = "";
         if(this._user.profile === undefined) {
-            name = this._user.username;
-        }
-        else {
-            name =  this._user.profile.name;
+            userName = this._user.username;
+        } else {
+            userName =  this._user.profile.name;
         }
 
         if(this._oldRole == undefined) {
@@ -52,11 +55,11 @@ export class RoleChangeMailHandler {
         if (this._user.emails && this._user.emails.length > 0) {
             let mailer = MailFactory.getMailer(adminFrom, emailTo);
             mailer.setSubject("Your role changed");
-            mailer.setText("Hello " + name + ", \n"+
-                "Your role in this Meeting changed: " + GlobalSettings.getRootUrl("meetingseries/" + this._meetingSeriesId) + "\n"+
-                "Your old role was          : " + this._oldRole + "\n"+
-                "Your new role is           : " + this._newRole + "\n"+
-                "The change was performed by: " + this._moderator.username + "\n"  +
+            mailer.setText("Hello " + userName + ", \n"+
+                "Your was changed in the meeting series \"" + meetingName + "\" (" + GlobalSettings.getRootUrl("meetingseries/" + this._meetingSeriesId) + ")\n"+
+                "Your old role was\t\t : " + this._oldRole + "\n"+
+                "Your new role is\t\t : " + this._newRole + "\n"+
+                "The change was performed by : " + this._moderator.username + "\n"  +
 
                 "\n" +
                 "Your Admin.\n" +

--- a/tests/end2end/MeetingSeriesEditUsers-test.js
+++ b/tests/end2end/MeetingSeriesEditUsers-test.js
@@ -496,5 +496,40 @@ describe('MeetingSeries Editor Users', function () {
 
         E2EApp.loginUser();
     });
-    
+
+    it('ensures participants gets E-Mail on role change', function () {
+         // Clear mails
+        E2EMails.resetSentMailsDb();
+
+         // Add user
+        let user2 = E2EGlobal.SETTINGS.e2eTestUsers[1];
+        E2EMeetingSeriesEditor.addUserToMeetingSeries(user2);
+        E2EMeetingSeriesEditor.closeMeetingSeriesEditor();
+
+        //check emais
+        let recipients = E2EMails.getAllRecipients();
+        // when the meeting is created an email is sent to the creator of the meeting as well. So we expect 2.
+        expect(recipients).to.have.length(2);
+    });
+
+    it('ensures participants does not get an E-Mail if roles stay the same', function () {
+         // Clear mails
+         E2EMails.resetSentMailsDb();
+
+         // Add user
+         E2EMeetingSeriesEditor.openMeetingSeriesEditor(aProjectName, aMeetingName, "invited");
+         E2EMeetingSeriesEditor.disableEmailForRoleChange();
+         let user2 = E2EGlobal.SETTINGS.e2eTestUsers[1];
+         E2EMeetingSeriesEditor.addUserToMeetingSeries(user2);
+         E2EMeetingSeriesEditor.closeMeetingSeriesEditor();
+
+         // open the dialog without saving roles and save
+         E2EMeetingSeriesEditor.openMeetingSeriesEditor(aProjectName, aMeetingName, "invited");
+         E2EMeetingSeriesEditor.closeMeetingSeriesEditor();
+
+         //check emails
+         let recipients = E2EMails.getAllRecipients();
+         expect(recipients).to.have.length(0);
+    });
+
 });

--- a/tests/end2end/MeetingSeriesEditUsers-test.js
+++ b/tests/end2end/MeetingSeriesEditUsers-test.js
@@ -444,6 +444,7 @@ describe('MeetingSeries Editor Users', function () {
         it('ensures informed user gets minutes email', function () {
             let currentUser = E2EApp.getCurrentUser();
             let user2 = E2EGlobal.SETTINGS.e2eTestUsers[1];
+            E2EMeetingSeriesEditor.disableEmailForRoleChange();
             E2EMeetingSeriesEditor.addUserToMeetingSeries(user2, E2EGlobal.USERROLES.Informed);
             E2EMeetingSeriesEditor.closeMeetingSeriesEditor();  // close with save
 
@@ -495,5 +496,5 @@ describe('MeetingSeries Editor Users', function () {
 
         E2EApp.loginUser();
     });
-
+    
 });

--- a/tests/end2end/MeetingSeriesEditUsers-test.js
+++ b/tests/end2end/MeetingSeriesEditUsers-test.js
@@ -498,7 +498,7 @@ describe('MeetingSeries Editor Users', function () {
         E2EApp.loginUser();
     });
 
-    it('ensures participants gets E-Mail on role change', function () {
+    it('ensures participants gets E-Mail on role change @watch', function () {
          // Clear mails
         E2EMails.resetSentMailsDb();
 
@@ -509,8 +509,7 @@ describe('MeetingSeries Editor Users', function () {
 
         //check emais
         let recipients = E2EMails.getAllRecipients();
-        // when the meeting is created an email is sent to the creator of the meeting as well. So we expect 2.
-        expect(recipients).to.have.length(2);
+        expect(recipients).to.have.length(1);
     });
 
     it('ensures participants does not get an E-Mail if roles stay the same', function () {

--- a/tests/end2end/MeetingSeriesEditUsers-test.js
+++ b/tests/end2end/MeetingSeriesEditUsers-test.js
@@ -442,6 +442,7 @@ describe('MeetingSeries Editor Users', function () {
     // this test does only make sense if mail delivery is enabled
     if (E2EGlobal.SETTINGS.email && E2EGlobal.SETTINGS.email.enableMailDelivery) {
         it('ensures informed user gets minutes email', function () {
+            E2EMails.resetSentMailsDb();
             let currentUser = E2EApp.getCurrentUser();
             let user2 = E2EGlobal.SETTINGS.e2eTestUsers[1];
             E2EMeetingSeriesEditor.disableEmailForRoleChange();

--- a/tests/end2end/SendAgenda.js
+++ b/tests/end2end/SendAgenda.js
@@ -111,6 +111,7 @@ describe('Send agenda', function () {
     it('ensures that the agenda will be sent to all invited', function() {
         E2EMeetingSeries.gotoMeetingSeries(aProjectName, aMeetingName);
         E2EMeetingSeriesEditor.openMeetingSeriesEditor(aProjectName, aMeetingName, "invited");
+        E2EMeetingSeriesEditor.disableEmailForRoleChange();
 
         let currentUser = E2EApp.getCurrentUser();
         let user2 = E2EGlobal.SETTINGS.e2eTestUsers[1];

--- a/tests/end2end/helpers/E2EMeetingSeriesEditor.js
+++ b/tests/end2end/helpers/E2EMeetingSeriesEditor.js
@@ -4,10 +4,10 @@ import { E2EMeetingSeries } from './E2EMeetingSeries'
 
 
 export class E2EMeetingSeriesEditor {
-    
-    static openMeetingSeriesEditor (aProj, aName, panelName = "base", skipGotoMeetingSeries) {
+
+    static openMeetingSeriesEditor(aProj, aName, panelName = "base", skipGotoMeetingSeries) {
         // Maybe we can save "gotoStartPage => gotoMeetingSeries"?
-        if (! skipGotoMeetingSeries) {
+        if (!skipGotoMeetingSeries) {
             E2EMeetingSeries.gotoMeetingSeries(aProj, aName);
         }
 
@@ -28,7 +28,7 @@ export class E2EMeetingSeriesEditor {
             else if (panelName == "labels") {
                 panelSelector = "#btnShowHideLabels";
             } else {
-                throw "Unsupported panelName: "+panelName;
+                throw "Unsupported panelName: " + panelName;
             }
             browser.waitForExist(panelSelector);
             browser.click(panelSelector);
@@ -37,7 +37,7 @@ export class E2EMeetingSeriesEditor {
     };
 
     // assumes an open meeting series editor
-    static addUserToMeetingSeries (username, role) {
+    static addUserToMeetingSeries(username, role) {
         browser.setValue('#edt_AddUser', username);
         browser.keys(['Enter']);
 
@@ -74,7 +74,7 @@ export class E2EMeetingSeriesEditor {
      * @param colNumDelete  in which 0-based table column is the delete button?
      * @returns {{}}
      */
-    static getUsersAndRoles (colNumUser, colNumRole, colNumDelete) {
+    static getUsersAndRoles(colNumUser, colNumRole, colNumDelete) {
         // grab all user rows
         const elementsUserRows = browser.elements('#id_userRow');
         let usersAndRoles = {};
@@ -84,7 +84,10 @@ export class E2EMeetingSeriesEditor {
         // except for the current user, who has no <select>
         let usrRoleSelected = [];
         // ensure we get an array here - even in case only one value returned from getValue()!
-        try {usrRoleSelected = usrRoleSelected.concat(browser.getValue(selector)); } catch(e) {}
+        try {
+            usrRoleSelected = usrRoleSelected.concat(browser.getValue(selector));
+        } catch (e) {
+        }
 
         let selectNum = 0;
         // the "current user" is read-only and has no <select>
@@ -95,27 +98,29 @@ export class E2EMeetingSeriesEditor {
             let usrName = browser.elementIdText(elementsTD.value[colNumUser].ELEMENT).value;
             let elementsDelete = browser.elementIdElements(elementsTD.value[colNumDelete].ELEMENT, "#btnDeleteUser");
             let usrIsDeletable = elementsDelete.value.length == 1;
-            let usrDeleteElemId = usrIsDeletable? elementsDelete.value[0].ELEMENT : "0";
+            let usrDeleteElemId = usrIsDeletable ? elementsDelete.value[0].ELEMENT : "0";
 
             // for the current user usrRole already contains his read-only role string "Moderator"
             let usrRole = browser.elementIdText(elementsTD.value[colNumRole].ELEMENT).value;
-            let usrIsReadOnly  = true;
+            let usrIsReadOnly = true;
 
             // For all other users we must get their role from the usrRoleSelected array
             // Here we try to find out, if we look at a <select> UI element...
             // Chrome: with '\n' linebreaks we detect a <select> for this user!
             // Phantom.js: Has no linebreaks between <option>s, it just concatenates like "InvitedModerator"
             // so we go for "usrRole.length>10" to detect a non-possible role text...
-            if (usrRole.indexOf("\n") >= 0 || usrRole.length>10) {
+            if (usrRole.indexOf("\n") >= 0 || usrRole.length > 10) {
                 usrRole = usrRoleSelected[selectNum];
                 usrIsReadOnly = false;
                 selectNum += 1;
             }
 
-            usersAndRoles[usrName] = {  role: usrRole,
+            usersAndRoles[usrName] = {
+                role: usrRole,
                 isReadOnly: usrIsReadOnly,
                 isDeletable: usrIsDeletable,
-                deleteElemId: usrDeleteElemId};
+                deleteElemId: usrDeleteElemId
+            };
         }
         // console.log(usersAndRoles);
 
@@ -155,5 +160,11 @@ export class E2EMeetingSeriesEditor {
             }
         }
     }
+
+    static disableEmailForRoleChange() {
+        browser.waitForVisible('#labelRoleChange');
+        browser.click('#labelRoleChange');
+    }
+
 
 }


### PR DESCRIPTION
You can now notify participants about a role change. With the help of the newly added checkbox you can select if they should be notified. Two E2E tests check if a mail gets send if a role changes and if no mail is sent when a role stays the same