### PR TITLE
Feature/minutes participant list link to invited editor of ms

### DIFF
--- a/client/templates/meetingseries/meetingSeriesEdit.js
+++ b/client/templates/meetingseries/meetingSeriesEdit.js
@@ -7,10 +7,14 @@ import { MeetingSeries } from '/imports/meetingseries';
 import { UsersEditConfig } from './meetingSeriesEditUsers';
 import { UserRoles } from '/imports/userroles';
 import { MinutesFinder } from "/imports/services/minutesFinder";
+import { Minutes } from '/imports/minutes';
 
 
 Template.meetingSeriesEdit.onCreated(function() {
     let thisMeetingSeriesID = FlowRouter.getParam('_id');
+    //Check if this dialog was not called by a meetingseries but by a minute
+    if (!MeetingSeries.findOne(thisMeetingSeriesID))
+        thisMeetingSeriesID = Minutes.findOne(thisMeetingSeriesID).parentMeetingSeriesID();
 
     // create client-only collection for storage of users attached
     // to this meeting series as input <=> output for the user editor

--- a/client/templates/minutes/minutesEditParticipants.html
+++ b/client/templates/minutes/minutesEditParticipants.html
@@ -1,5 +1,7 @@
 <template name="minutesEditParticipants">
     <div class="panel default-margin-top">
+        <!--Include modal dialog for edit meeting series -->
+        {{> meetingSeriesEdit parentMeetingSeries}} 
         <div class="panel-heading bright">
             <label for="id_participants" id="btnParticipantsExpand">
                 {{#if isParticipantsExpanded}}
@@ -9,6 +11,11 @@
                 {{/if}}
                 Participants (& Informed)
             </label>
+            {{#if isEditable}}
+                <a href="#" id="btnEditParticipants" class="pull-right" data-toggle="modal" data-target="#dlgEditMeetingSeries">
+                    <span class="glyphicon glyphicon-pencil grey-icon hidden-print"></span>
+                </a>
+            {{/if}}
         </div>
 
         <div class="panel-body force-no-padding-top">

--- a/client/templates/minutes/minutesEditParticipants.js
+++ b/client/templates/minutes/minutesEditParticipants.js
@@ -116,6 +116,15 @@ Template.minutesEditParticipants.helpers({
 
     isChecked(){
         return Template.instance().markedAll.get();
+    },
+    
+    isEditable() {
+        return isEditable();
+    },
+    
+    parentMeetingSeries() {
+        let aMin = new Minutes(_minutesID);
+        return aMin.parentMeetingSeries();
     }
 });
 
@@ -150,5 +159,9 @@ Template.minutesEditParticipants.events({
             aMin.changeParticipantsStatus(true).catch(handleError);
             tmpl.markedAll.set(true);
         }
+    },
+    
+    'click #btnEditParticipants' (evt, tmpl) {
+        Session.set('meetingSeriesEdit.showUsersPanel', true);
     }
 });

--- a/client/templates/minutes/minutesedit.html
+++ b/client/templates/minutes/minutesedit.html
@@ -154,7 +154,7 @@
                                     <span class="hidden-xs">Add</span> Topic...
                                 </button>
                             </div>
-                            <div class="checkbox-hide-topics visible-xs col-xs-6 checkbox">
+                            <div class="checkbox-hide-topics visible-xs col-xs-6 checkbox hidden-print">
                                 <label class="text-black">
                                     <input type="checkbox" id="checkHideClosedTopics" class="checkbox"/>Hide closed
                                 </label>

--- a/client/templates/topic/topicElement.html
+++ b/client/templates/topic/topicElement.html
@@ -22,7 +22,7 @@
                     {{topic.subject}}
                     {{responsiblesHelper}}
                     </span>
-                    <span class="labels">
+                    <span class="labels topic-labels">
                         <!-- Labels -->
                         {{#each getLabels}}
                             <span class="label" style="background-color: {{color}}; color: {{fontColor}}">{{name}}</span>

--- a/tests/end2end/MinutesParticipants-test.js
+++ b/tests/end2end/MinutesParticipants-test.js
@@ -241,4 +241,18 @@ describe('Minutes Participants', function () {
         E2EMeetingSeries.gotoMeetingSeries(aProjectName, aMeetingName);
         expect(browser.getText("tr#id_MinuteRow")).to.contain("user1, user3, Max Mustermann");
     });
+    
+    it('can edit participants from within a minute as a moderator', function () {
+        let participantsInfo = new E2EMinutesParticipants();
+        expect(participantsInfo.getParticipantsCount()).to.equal(1);
+        
+        browser.click("#btnEditParticipants");
+        E2EGlobal.waitSomeTime(750);
+        let user2 = E2EGlobal.SETTINGS.e2eTestUsers[1];
+        E2EMeetingSeriesEditor.addUserToMeetingSeries(user2);
+        E2EMeetingSeriesEditor.closeMeetingSeriesEditor();  // close with save
+        
+        participantsInfo = new E2EMinutesParticipants();
+        expect(participantsInfo.getParticipantsCount()).to.equal(2);
+    }); 
 });

--- a/tests/end2end/Topics-test.js
+++ b/tests/end2end/Topics-test.js
@@ -457,8 +457,8 @@ describe('Topics', function () {
         E2ETopics.addTopicWithLabelToMinutes('topic', labelName);
         E2EGlobal.waitSomeTime(500);
 
-        expect(browser.waitForExist(".labels")).to.be.true;
-        expect(browser.getText(".label")).to.equal(labelName);
+        expect(browser.waitForExist(".topic-labels")).to.be.true;
+        expect(browser.getText(".topic-labels .label")).to.equal(labelName);
     });
 
     it('add label to topic via textbox', function() {
@@ -466,8 +466,8 @@ describe('Topics', function () {
         E2ETopics.addTopicToMinutes('topic #' + labelName);
         E2EGlobal.waitSomeTime(500);
 
-        expect(browser.waitForExist(".labels")).to.be.true;
-        expect(browser.getText(".label")).to.equal(labelName);
+        expect(browser.waitForExist(".topic-labels")).to.be.true;
+        expect(browser.getText(".topic-labels .label")).to.equal(labelName);
     });
 
     it('add more (2) labels to topic via textbox', function() {
@@ -477,9 +477,9 @@ describe('Topics', function () {
         E2ETopics.addTopicToMinutes(topicName + ' #' + labelName1 + ' #' + labelName2);
         E2EGlobal.waitSomeTime(500);
 
-        expect(browser.waitForExist(".labels")).to.be.true;
-        expect(browser.getText(".labels .label:nth-child(1)")).to.equal(labelName1);
-        expect(browser.getText(".labels .label:nth-child(2)")).to.equal(labelName2);
+        expect(browser.waitForExist(".topic-labels")).to.be.true;
+        expect(browser.getText(".topic-labels .label:nth-child(1)")).to.equal(labelName1);
+        expect(browser.getText(".topic-labels .label:nth-child(2)")).to.equal(labelName2);
     });
 
     it('add label to topic and check if topic is displayed in topic tab of meeting series', function() {
@@ -491,8 +491,8 @@ describe('Topics', function () {
         E2EMinutes.gotoParentMeetingSeries();
         E2EMeetingSeries.gotoTabTopics();
 
-        expect(browser.waitForExist(".labels")).to.be.true;
-        expect(browser.getText(".labels .label")).to.equal(labelName);
+        expect(browser.waitForExist(".topic-labels")).to.be.true;
+        expect(browser.getText(".topic-labels .label")).to.equal(labelName);
     });
 
     it('can add a topic with label to minutes at the end of topics list', function() {
@@ -504,8 +504,8 @@ describe('Topics', function () {
 
         expect(E2ETopics.countTopicsForMinute()).to.equal(2);
         expect(E2ETopics.getLastTopicForMinute() === testTopicName);
-        expect(browser.waitForExist(".labels")).to.be.true;
-        expect(browser.getText(".label")).to.equal(labelName);
+        expect(browser.waitForExist(".topic-labels")).to.be.true;
+        expect(browser.getText(".topic-labels .label")).to.equal(labelName);
     });
 
     it('can add a topic with more (2) labels to minutes at the end of topics list', function() {
@@ -519,8 +519,8 @@ describe('Topics', function () {
         expect(E2ETopics.countTopicsForMinute()).to.equal(2);
         expect(E2ETopics.getLastTopicForMinute() === testTopicName);
         expect(browser.waitForExist(".labels")).to.be.true;
-        expect(browser.getText(".labels .label:nth-child(1)")).to.equal(labelName1);
-        expect(browser.getText(".labels .label:nth-child(2)")).to.equal(labelName2);
+        expect(browser.getText(".topic-labels .label:nth-child(1)")).to.equal(labelName1);
+        expect(browser.getText(".topic-labels .label:nth-child(2)")).to.equal(labelName2);
     });
 
     it('can add a topic with responsible to minutes at the end of topics list', function() {
@@ -564,8 +564,8 @@ describe('Topics', function () {
 
         expect(E2ETopics.countTopicsForMinute()).to.equal(2);
         expect(E2ETopics.getLastTopicForMinute() === testTopicName);
-        expect(browser.waitForExist(".labels")).to.be.true;
-        expect(browser.getText(".label")).to.equal(labelName);
+        expect(browser.waitForExist(".topic-labels")).to.be.true;
+        expect(browser.getText(".topic-labels .label")).to.equal(labelName);
         expect (topicHeadingText).to.contain(responsibleName);
     });
 });


### PR DESCRIPTION
It is now possible to open the participants-edit-dialog directly from a Minute by using a new edit-button within the participants-area.
Also sneaked in a minor bugfix for the "Print Minute"-Feature. The "Hide closed Topics"-Button has not been correctly hidden on the printed document.

And a small hint related to the changes in the file "Topics-Test": Due to the embedding of the meetingseries-edit-dialog in the Minute the "Label"-class became ambiguous between the Labels within the mentioned edit-dialog and the Labels of Topics. Therefore a separated class has been added for clear distinction.