### PR TITLE
Feature/#331 protocols download on firefox incl dyn generation

### DIFF
--- a/client/templates/minutes/minutesedit.html
+++ b/client/templates/minutes/minutesedit.html
@@ -52,11 +52,14 @@
                                           aria-label="Print View"></span>
                                 </button>
                                 {{#if isDocumentGenerationAllowed}}
-                                    <button type="button" id="btn_downloadMinutes" class="btn hidden-print"
-                                            title="Download Minutes">
-                                        <span class="glyphicon glyphicon-download" aria-hidden="true"
-                                              aria-label="Download Minutes"></span>
-                                    </button>
+                                    {{#with theProtocol}}
+                                        <a class= "btn hidden-print" href="{{link}}?download=true"
+                                           target="_parent" type="{{type}}" download="{{name}}"
+                                            title="Download minutes as file">
+                                            <span class="glyphicon glyphicon-download" aria-hidden="true"
+                                                  aria-label="Download Minutes"></span>
+                                        </a>
+                                    {{/with}}
                                 {{/if}}
                             </div>
                         {{else}}  <!--NOT isFinalized-->

--- a/client/templates/minutes/minutesedit.html
+++ b/client/templates/minutes/minutesedit.html
@@ -52,14 +52,21 @@
                                           aria-label="Print View"></span>
                                 </button>
                                 {{#if isDocumentGenerationAllowed}}
-                                    {{#with theProtocol}}
-                                        <a class= "btn hidden-print" href="{{link}}?download=true"
-                                           target="_parent" type="{{type}}" download="{{name}}"
-                                            title="Download minutes as file">
+                                    {{#if theProtocol}} <!--Protocol exists -->
+                                        {{#with theProtocol}}
+                                            <a class= "btn hidden-print btn-download" href="{{link}}?download=true"
+                                                target="_parent" type="{{type}}" download="{{name}}"
+                                                title="Download minutes as file">
+                                                <span class="glyphicon glyphicon-download" aria-hidden="true"
+                                                    aria-label="Download Minutes"></span>
+                                            </a>
+                                        {{/with}}
+                                    {{else}} <!--No Protocol exists, offer to dynamically generate one -->
+                                        <a class="btn hidden-print btn-download" id="btn_dynamicallyGenerateProtocol">
                                             <span class="glyphicon glyphicon-download" aria-hidden="true"
-                                                  aria-label="Download Minutes"></span>
+                                                aria-label="Download Minutes"></span>
                                         </a>
-                                    {{/with}}
+                                    {{/if}}
                                 {{/if}}
                             </div>
                         {{else}}  <!--NOT isFinalized-->

--- a/client/templates/minutes/minutesedit.js
+++ b/client/templates/minutes/minutesedit.js
@@ -602,7 +602,7 @@ Template.minutesedit.events({
         togglePrintView();
     },
 
-    'click #btn_downloadMinutes': function(evt) {
+    'click #btn_dynamicallyGenerateProtocol': function(evt) {
         evt.preventDefault();
 
         let noProtocolExistsDialog = (downloadHTML) => {
@@ -614,7 +614,7 @@ Template.minutesedit.events({
                 'Download'
             ).show();
         };
-
+        
         DocumentGeneration.downloadMinuteProtocol(_minutesID, noProtocolExistsDialog).catch(onError);
     }
 });

--- a/client/templates/minutes/minutesedit.js
+++ b/client/templates/minutes/minutesedit.js
@@ -401,7 +401,11 @@ Template.minutesedit.helpers({
 
     isDocumentGenerationAllowed : function () {
         return Meteor.settings.public.docGeneration.enabled === true;
-    }
+    },
+
+    theProtocol : function () {
+        return DocumentGeneration.getProtocolForMinute(_minutesID);
+    },
 });
 
 Template.minutesedit.events({

--- a/imports/documentGeneration.js
+++ b/imports/documentGeneration.js
@@ -18,44 +18,38 @@ import {ResponsibleResolver} from './services/responsibleResolver';
 export class DocumentGeneration {
     // ********** static methods ****************
     static async downloadMinuteProtocol(minuteID, noProtocolExistsDialog) {
-        // This function checks if a protocol for this minute has been generated.
-        // If this is the case the protocol will be downloaded
-        // Otherwise an HTML document may be generated on-the-fly
-        let minprotocol = DocumentGeneration.getProtocolForMinute(minuteID);
-        if (minprotocol) {
-            window.location = minprotocol.link() + '?download=true';
-        } else {
-            let generateAndDownloadHTML = async function() {
-                let minuteID = FlowRouter.getParam('_id'); //eslint-disable-line
+        // This Function dynamically generates an HTML document for instant-download
+        let generateAndDownloadHTML = async function() {
+            let minuteID = FlowRouter.getParam('_id'); //eslint-disable-line
 
-                //Create HTML
-                let htmldata = await Meteor.callPromise('documentgeneration.createHTML', minuteID);
-                let currentMinute = new Minutes(minuteID);
-                //Download File
-                let fileBlob = new Blob([htmldata], {type:'octet/stream'});
+            //Create HTML
+            let htmldata = await Meteor.callPromise('documentgeneration.createHTML', minuteID);
+            let currentMinute = new Minutes(minuteID);
+            //Download File
+            let fileBlob = new Blob([htmldata], {type:'octet/stream'});
 
-                const filename = DocumentGeneration.calcFileNameforMinute(currentMinute) + '.html';
+            const filename = DocumentGeneration.calcFileNameforMinute(currentMinute) + '.html';
 
-                if (window.navigator.msSaveOrOpenBlob) { // necessary for Internet Explorer, since it does'nt support the download-attribute for anchors
-                    window.navigator.msSaveBlob(fileBlob, filename);
-                } else {
-                    let fileurl  = window.URL.createObjectURL(fileBlob);
+            if (window.navigator.msSaveOrOpenBlob) { // necessary for Internet Explorer, since it does'nt support the download-attribute for anchors
+                window.navigator.msSaveBlob(fileBlob, filename);
+            } else {
+                let fileurl  = window.URL.createObjectURL(fileBlob);
 
-                    let a = document.createElement('a');
-                    document.body.appendChild(a);
-                    a.style = 'display: none';
-                    a.href = fileurl;
-                    a.download = filename;
-                    a.click();
+                let a = document.createElement('a');
+                document.body.appendChild(a);
+                a.style = 'display: none';
+                a.href = fileurl;
+                a.download = filename;
+                a.click();
 
-                    setTimeout(function () {
-                        window.URL.revokeObjectURL(fileurl);
-                    }, 250);
-                }
-            };
-            noProtocolExistsDialog(generateAndDownloadHTML);
-        }
+                setTimeout(function () {
+                    window.URL.revokeObjectURL(fileurl);
+                }, 250);
+            }
+        };
+        noProtocolExistsDialog(generateAndDownloadHTML);
     }
+    
     static getProtocolForMinute(minuteId) {
         return DocumentsCollection.findOne({'meta.minuteId': minuteId});
     }

--- a/tests/end2end/helpers/E2EProtocols.js
+++ b/tests/end2end/helpers/E2EProtocols.js
@@ -30,11 +30,11 @@ export class E2EProtocols {
     }
 
     static downloadButtonExists() {
-        return browser.isVisible('#btn_downloadMinutes');
+        return browser.isVisible('.btn-download');
     }
 
     static checkDownloadOpensConfirmationDialog() {
-        browser.click('#btn_downloadMinutes');
+        browser.click('.btn-download');
         E2EGlobal.waitSomeTime(750);
         return browser.isVisible('#confirmationDialogOK');
     }


### PR DESCRIPTION
Fixed a bug preventing the download of Minute protocols with Firefox.
Works with both static and dynamically generated protocols.