### PR TITLE
Feature/#343 performance of typeahead/select2 with thousands of users

### DIFF
--- a/client/templates/topic/optionElements.html
+++ b/client/templates/topic/optionElements.html
@@ -1,0 +1,5 @@
+<template name="optionsElement">
+    {{#each options}}
+        <option value="{{optionId}}" selected="selected">{{optionText}}</option>
+    {{/each}}
+</template>

--- a/client/templates/topic/topicEdit.js
+++ b/client/templates/topic/topicEdit.js
@@ -10,6 +10,7 @@ import { $ } from 'meteor/jquery';
 import { handleError } from '/client/helpers/handleError';
 import {createTopic} from './helpers/create-topic';
 import {select2search} from '/imports/client/ResponsibleSearch';
+import {addResponsibleOptions} from '/imports/client/ResponsibleSearch';
 
 Session.setDefault('topicEditTopicId', null);
 
@@ -40,22 +41,8 @@ function configureSelect2Responsibles() {
     let delayTime = Meteor.settings.public.isEnd2EndTest ? 0 : 50;
 
     select2search(selectResponsibles, delayTime, true, _minutesID);
-
-    // select the options that where stored with this topic last time
     let topic = getEditTopic();
-    let data = {options: []};
-    if (topic && topic._topicDoc && topic._topicDoc.responsibles) {
-        topic._topicDoc.responsibles.forEach(responsibleId => {
-            let responsibleUser = Meteor.users.findOne(responsibleId);
-            if (!responsibleUser) { //free text user
-                responsibleUser = {fullname: responsibleId};
-            } else {
-                Minutes.formatResponsibles(responsibleUser, 'username', responsibleUser.profile);
-            }
-            data.options.push({optionId: responsibleId, optionText: responsibleUser.fullname});
-        });
-        Blaze.renderWithData(Template['optionsElement'], data, document.getElementById('id_selResponsible'));
-    }
+    addResponsibleOptions('id_selResponsible', topic._topicDoc);
     selectResponsibles.trigger('change');
 }
 

--- a/client/templates/topic/topicEdit.js
+++ b/client/templates/topic/topicEdit.js
@@ -36,9 +36,7 @@ function configureSelect2Responsibles() {
     let selectResponsibles = $('#id_selResponsible');
     selectResponsibles.find('optgroup')     // clear all <option>s
         .remove();
-    let delayTime = 50;
-    if (Meteor.settings.public.isEnd2EndTest)
-        delayTime = 0;
+    let delayTime = Meteor.settings.public.isEnd2EndTest ? 0 : 50;
 
     selectResponsibles.select2({
         placeholder: 'Select...',
@@ -59,7 +57,7 @@ function configureSelect2Responsibles() {
                 let results_participants = [];
                 let results_other = [];
                 _.each(data.results, function (result) {
-                    if (result.isParticipant === true) {
+                    if (result.isParticipant) {
                         results_participants.push({
                             id: result.userId,
                             text: result.fullname

--- a/client/templates/topic/topicEdit.js
+++ b/client/templates/topic/topicEdit.js
@@ -42,8 +42,9 @@ function configureSelect2Responsibles() {
         tags: true,                     // Allow freetext adding
         tokenSeparators: [',', ';'],
         ajax: {
+            delay: 50,
             transport: function(params, success, failure) {
-                Meteor.call('responsiblesSearch', params.data.q, _minutesID, function(err, results) {
+                Meteor.call('responsiblesSearch', params.data.q, _minutesID, true, function(err, results) {
                     if (err) {
                         failure(err);
                         return;

--- a/client/templates/topic/topicEdit.js
+++ b/client/templates/topic/topicEdit.js
@@ -36,13 +36,16 @@ function configureSelect2Responsibles() {
     let selectResponsibles = $('#id_selResponsible');
     selectResponsibles.find('optgroup')     // clear all <option>s
         .remove();
+    let delayTime = 50;
+    if (Meteor.settings.public.isEnd2EndTest)
+        delayTime = 0;
 
     selectResponsibles.select2({
         placeholder: 'Select...',
         tags: true,                     // Allow freetext adding
         tokenSeparators: [',', ';'],
         ajax: {
-            delay: 50,
+            delay: delayTime,
             transport: function(params, success, failure) {
                 Meteor.call('responsiblesSearch', params.data.q, _minutesID, true, function(err, results) {
                     if (err) {

--- a/client/templates/topic/topicEdit.js
+++ b/client/templates/topic/topicEdit.js
@@ -9,8 +9,7 @@ import { Label } from '/imports/label';
 import { $ } from 'meteor/jquery';
 import { handleError } from '/client/helpers/handleError';
 import {createTopic} from './helpers/create-topic';
-import {select2search} from '/imports/client/ResponsibleSearch';
-import {addResponsibleOptions} from '/imports/client/ResponsibleSearch';
+import {configureSelect2Responsibles} from '/imports/client/ResponsibleSearch';
 
 Session.setDefault('topicEditTopicId', null);
 
@@ -33,18 +32,6 @@ let getEditTopic = function() {
 
     return new Topic(_minutesID, topicId);
 };
-
-function configureSelect2Responsibles() {
-    let selectResponsibles = $('#id_selResponsible');
-    selectResponsibles.find('option')     // clear all <option>s
-        .remove();
-    let delayTime = Meteor.settings.public.isEnd2EndTest ? 0 : 50;
-
-    select2search(selectResponsibles, delayTime, true, _minutesID);
-    let topic = getEditTopic();
-    addResponsibleOptions('id_selResponsible', topic._topicDoc);
-    selectResponsibles.trigger('change');
-}
 
 function configureSelect2Labels() {
     let aMin = new Minutes(_minutesID);
@@ -126,7 +113,8 @@ Template.topicEdit.events({
     },
 
     'show.bs.modal #dlgAddTopic': function () {
-        configureSelect2Responsibles();
+        let topic = getEditTopic();
+        configureSelect2Responsibles('id_selResponsible', topic._topicDoc, true, _minutesID);
         let selectLabels = $('#id_item_selLabels');
         if (selectLabels) {
             selectLabels.val([]).trigger('change');

--- a/client/templates/topic/topicEdit.js
+++ b/client/templates/topic/topicEdit.js
@@ -43,6 +43,7 @@ function configureSelect2Responsibles() {
 
     // select the options that where stored with this topic last time
     let topic = getEditTopic();
+    let data = {options: []};
     if (topic && topic._topicDoc && topic._topicDoc.responsibles) {
         topic._topicDoc.responsibles.forEach(responsibleId => {
             let responsibleUser = Meteor.users.findOne(responsibleId);
@@ -51,9 +52,9 @@ function configureSelect2Responsibles() {
             } else {
                 Minutes.formatResponsibles(responsibleUser, 'username', responsibleUser.profile);
             }
-            selectResponsibles.append('<option value="' + responsibleId + '" selected="selected">' + responsibleUser.fullname + '</option>');
+            data.options.push({optionId: responsibleId, optionText: responsibleUser.fullname});
         });
-        selectResponsibles.val(topic._topicDoc.responsibles);
+        Blaze.renderWithData(Template['optionsElement'], data, document.getElementById('id_selResponsible'));
     }
     selectResponsibles.trigger('change');
 }

--- a/client/templates/topic/topicEdit.js
+++ b/client/templates/topic/topicEdit.js
@@ -51,26 +51,45 @@ function configureSelect2Responsibles() {
         tokenSeparators: [',', ';'],
         ajax: {
             transport: function(params, success, failure) {
-                Meteor.call('respSearch', params.data.q, function(err, results) {
+                Meteor.call('respSearch', params.data.q, _minutesID, function(err, results) {
                     if (err) {
                         failure(err);
                         return;
                     }
-
                     success(results);
                 });
             },
             processResults: function(data) {
-                var results = [];
+                var results_participants = [];
+                var results_other = [];
                 _.each(data.results, function (result) {
-                    results.push({
+                    if (result.isParticipant == true) {
+                        results_participants.push({
+                            id: result.userId,
+                            text: result.name
+                        });
+                    }
+                    else results_other.push({
                         id: result._id,
                         text: result.username
                     });
                 });
+                // save the return value (when participants/other user are empty -> do not show a group-name
+                let returnValues = [];
+                if (results_participants.length == 0 && results_other.length == 0)
+                    returnValues = [];
+                else if (results_participants.length == 0)
+                    returnValues = [{text:'Other Users', children: results_other}];
+                else if (results_other.length == 0)
+                    returnValues = [{text:'Participants', children: results_participants}];
+                else
+                    returnValues = [
+                        {text:'Participants', children: results_participants},
+                        {text:'Other Users', children: results_other}
+                    ];
+
                 return {
-                    results:
-                        [{text:'Other Users', children: results}]
+                    results:returnValues
                 };
             }}
     });

--- a/client/templates/topic/topicEdit.js
+++ b/client/templates/topic/topicEdit.js
@@ -35,7 +35,7 @@ let getEditTopic = function() {
 
 function configureSelect2Responsibles() {
     let selectResponsibles = $('#id_selResponsible');
-    selectResponsibles.find('optgroup')     // clear all <option>s
+    selectResponsibles.find('option')     // clear all <option>s
         .remove();
     let delayTime = Meteor.settings.public.isEnd2EndTest ? 0 : 50;
 
@@ -44,6 +44,15 @@ function configureSelect2Responsibles() {
     // select the options that where stored with this topic last time
     let topic = getEditTopic();
     if (topic && topic._topicDoc && topic._topicDoc.responsibles) {
+        topic._topicDoc.responsibles.forEach(responsibleId => {
+            let responsibleUser = Meteor.users.findOne(responsibleId);
+            if (!responsibleUser) { //free text user
+                responsibleUser = {fullname: responsibleId};
+            } else {
+                (new Minutes(_minutesID)).formatResponsibles(responsibleUser, 'username', responsibleUser.profile);
+            }
+            selectResponsibles.append('<option value="' + responsibleId + '" selected="selected">' + responsibleUser.fullname + '</option>');
+        });
         selectResponsibles.val(topic._topicDoc.responsibles);
     }
     selectResponsibles.trigger('change');

--- a/client/templates/topic/topicEdit.js
+++ b/client/templates/topic/topicEdit.js
@@ -58,12 +58,12 @@ function configureSelect2Responsibles() {
                     if (result.isParticipant === true) {
                         results_participants.push({
                             id: result.userId,
-                            text: result.name
+                            text: result.fullname
                         });
                     }
                     else results_other.push({
                         id: result._id,
-                        text: result.username
+                        text: result.fullname
                     });
                 });
                 // save the return value (when participants/other user are empty -> do not show a group-name

--- a/client/templates/topic/topicEdit.js
+++ b/client/templates/topic/topicEdit.js
@@ -9,6 +9,7 @@ import { Label } from '/imports/label';
 import { $ } from 'meteor/jquery';
 import { handleError } from '/client/helpers/handleError';
 import {createTopic} from './helpers/create-topic';
+import {select2search} from '/imports/client/ResponsibleSearch';
 
 Session.setDefault('topicEditTopicId', null);
 
@@ -38,48 +39,7 @@ function configureSelect2Responsibles() {
         .remove();
     let delayTime = Meteor.settings.public.isEnd2EndTest ? 0 : 50;
 
-    selectResponsibles.select2({
-        placeholder: 'Select...',
-        tags: true,                     // Allow freetext adding
-        tokenSeparators: [',', ';'],
-        ajax: {
-            delay: delayTime,
-            transport: function(params, success, failure) {
-                Meteor.call('responsiblesSearch', params.data.q, _minutesID, true, function(err, results) {
-                    if (err) {
-                        failure(err);
-                        return;
-                    }
-                    success(results);
-                });
-            },
-            processResults: function(data) {
-                let results_participants = [];
-                let results_other = [];
-                _.each(data.results, function (result) {
-                    if (result.isParticipant) {
-                        results_participants.push({
-                            id: result.userId,
-                            text: result.fullname
-                        });
-                    }
-                    else results_other.push({
-                        id: result._id,
-                        text: result.fullname
-                    });
-                });
-                // save the return value (when participants/other user are empty -> do not show a group-name
-                let returnValues = [];
-                if (results_participants.length > 0)
-                    returnValues.push({text:'Participants', children: results_participants});
-                if (results_other.length > 0)
-                    returnValues.push({text:'Other Users', children: results_other});
-
-                return {
-                    results:returnValues
-                };
-            }}
-    });
+    select2search(selectResponsibles, delayTime, true, _minutesID);
 
     // select the options that where stored with this topic last time
     let topic = getEditTopic();

--- a/client/templates/topic/topicEdit.js
+++ b/client/templates/topic/topicEdit.js
@@ -49,7 +49,7 @@ function configureSelect2Responsibles() {
             if (!responsibleUser) { //free text user
                 responsibleUser = {fullname: responsibleId};
             } else {
-                (new Minutes(_minutesID)).formatResponsibles(responsibleUser, 'username', responsibleUser.profile);
+                Minutes.formatResponsibles(responsibleUser, 'username', responsibleUser.profile);
             }
             selectResponsibles.append('<option value="' + responsibleId + '" selected="selected">' + responsibleUser.fullname + '</option>');
         });

--- a/client/templates/topic/topicInfoItemEdit.js
+++ b/client/templates/topic/topicInfoItemEdit.js
@@ -24,7 +24,6 @@ import { ReactiveVar } from 'meteor/reactive-var';
 import { handleError } from '/client/helpers/handleError';
 import {LabelExtractor} from '../../../imports/services/labelExtractor';
 import {select2search} from '/imports/client/ResponsibleSearch';
-import { Blaze } from 'meteor/blaze';
 import {addResponsibleOptions} from '/imports/client/ResponsibleSearch';
 
 Session.setDefault('topicInfoItemEditTopicId', null);

--- a/client/templates/topic/topicInfoItemEdit.js
+++ b/client/templates/topic/topicInfoItemEdit.js
@@ -24,6 +24,8 @@ import { ReactiveVar } from 'meteor/reactive-var';
 import { handleError } from '/client/helpers/handleError';
 import {LabelExtractor} from '../../../imports/services/labelExtractor';
 import {select2search} from '/imports/client/ResponsibleSearch';
+import { Blaze } from 'meteor/blaze';
+import {addResponsibleOptions} from '/imports/client/ResponsibleSearch';
 
 Session.setDefault('topicInfoItemEditTopicId', null);
 Session.setDefault('topicInfoItemEditInfoItemId', null);
@@ -99,22 +101,8 @@ function configureSelect2Responsibles() {
     let delayTime = Meteor.settings.public.isEnd2EndTest ? 0 : 50;
 
     select2search(selectResponsibles, delayTime, false, _minutesID);
-
-    //select the options that where stored with this item last time
     let editItem = getEditInfoItem();
-    let data = {options: []};
-    if (editItem && editItem._infoItemDoc && editItem._infoItemDoc.responsibles) {
-        editItem._infoItemDoc.responsibles.forEach(responsibleId => {
-            let responsibleUser = Meteor.users.findOne(responsibleId);
-            if (!responsibleUser) { //free text user
-                responsibleUser = {fullname: responsibleId};
-            } else {
-                Minutes.formatResponsibles(responsibleUser, 'username', responsibleUser.profile);
-            }
-            data.options.push({optionId: responsibleId, optionText: responsibleUser.fullname});
-        });
-        Blaze.renderWithData(Template['optionsElement'], data, document.getElementById('id_selResponsibleActionItem'));
-    }
+    addResponsibleOptions('id_selResponsibleActionItem', editItem._infoItemDoc);
     selectResponsibles.trigger('change');
 }
 

--- a/client/templates/topic/topicInfoItemEdit.js
+++ b/client/templates/topic/topicInfoItemEdit.js
@@ -96,13 +96,16 @@ function configureSelect2Responsibles() {
     let selectResponsibles = $('#id_selResponsibleActionItem');
     selectResponsibles.find('optgroup')     // clear all <option>s
         .remove();
+    let delayTime = 50;
+    if (Meteor.settings.public.isEnd2EndTest)
+        delayTime = 0;
 
     selectResponsibles.select2({
         placeholder: 'Select...',
         tags: true,                     // Allow freetext adding
         tokenSeparators: [',', ';'],
         ajax: {
-            delay: 50,
+            delay: delayTime,
             transport: function(params, success, failure) {
                 Meteor.call('responsiblesSearch', params.data.q, _minutesID, false, function(err, results) {
                     if (err) {

--- a/client/templates/topic/topicInfoItemEdit.js
+++ b/client/templates/topic/topicInfoItemEdit.js
@@ -102,8 +102,9 @@ function configureSelect2Responsibles() {
         tags: true,                     // Allow freetext adding
         tokenSeparators: [',', ';'],
         ajax: {
+            delay: 50,
             transport: function(params, success, failure) {
-                Meteor.call('responsiblesSearch', params.data.q, _minutesID, function(err, results) {
+                Meteor.call('responsiblesSearch', params.data.q, _minutesID, false, function(err, results) {
                     if (err) {
                         failure(err);
                         return;

--- a/client/templates/topic/topicInfoItemEdit.js
+++ b/client/templates/topic/topicInfoItemEdit.js
@@ -15,7 +15,6 @@ import { Label } from '/imports/label';
 import { Priority } from '/imports/priority';
 import { User, userSettings } from '/imports/users';
 
-import { ResponsiblePreparer } from '/imports/client/ResponsiblePreparer';
 import { currentDatePlusDeltaDays } from '/imports/helpers/date';
 import { emailAddressRegExpTest } from '/imports/helpers/email';
 
@@ -24,6 +23,7 @@ import { _ } from 'meteor/underscore';
 import { ReactiveVar } from 'meteor/reactive-var';
 import { handleError } from '/client/helpers/handleError';
 import {LabelExtractor} from '../../../imports/services/labelExtractor';
+import {select2search} from '/imports/client/ResponsibleSearch';
 
 Session.setDefault('topicInfoItemEditTopicId', null);
 Session.setDefault('topicInfoItemEditInfoItemId', null);
@@ -98,48 +98,7 @@ function configureSelect2Responsibles() {
         .remove();
     let delayTime = Meteor.settings.public.isEnd2EndTest ? 0 : 50;
 
-    selectResponsibles.select2({
-        placeholder: 'Select...',
-        tags: true,                     // Allow freetext adding
-        tokenSeparators: [',', ';'],
-        ajax: {
-            delay: delayTime,
-            transport: function(params, success, failure) {
-                Meteor.call('responsiblesSearch', params.data.q, _minutesID, false, function(err, results) {
-                    if (err) {
-                        failure(err);
-                        return;
-                    }
-                    success(results);
-                });
-            },
-            processResults: function(data) {
-                let results_participants = [];
-                let results_other = [];
-                _.each(data.results, function (result) {
-                    if (result.isParticipant) {
-                        results_participants.push({
-                            id: result.userId,
-                            text: result.fullname
-                        });
-                    }
-                    else results_other.push({
-                        id: result._id,
-                        text: result.fullname
-                    });
-                });
-                // save the return value (when participants/other user are empty -> do not show a group-name
-                let returnValues = [];
-                if (results_participants.length > 0)
-                    returnValues.push({text:'Participants', children: results_participants});
-                if (results_other.length > 0)
-                    returnValues.push({text:'Other Users', children: results_other});
-
-                return {
-                    results:returnValues
-                };
-            }}
-    });
+    select2search(selectResponsibles, delayTime, false, _minutesID);
 
     // select the options that where stored with this topic last time
     let editItem = getEditInfoItem();

--- a/client/templates/topic/topicInfoItemEdit.js
+++ b/client/templates/topic/topicInfoItemEdit.js
@@ -94,16 +94,26 @@ let toggleItemMode = function (type, tmpl) {
 
 function configureSelect2Responsibles() {
     let selectResponsibles = $('#id_selResponsibleActionItem');
-    selectResponsibles.find('optgroup')     // clear all <option>s
+    selectResponsibles.find('option')     // clear all <option>s
         .remove();
     let delayTime = Meteor.settings.public.isEnd2EndTest ? 0 : 50;
 
     select2search(selectResponsibles, delayTime, false, _minutesID);
 
-    // select the options that where stored with this topic last time
+    //select the options that where stored with this item last time
     let editItem = getEditInfoItem();
-    if (editItem) {
-        selectResponsibles.val(editItem.getResponsibleRawArray());
+    let data = {options: []};
+    if (editItem && editItem._infoItemDoc && editItem._infoItemDoc.responsibles) {
+        editItem._infoItemDoc.responsibles.forEach(responsibleId => {
+            let responsibleUser = Meteor.users.findOne(responsibleId);
+            if (!responsibleUser) { //free text user
+                responsibleUser = {fullname: responsibleId};
+            } else {
+                Minutes.formatResponsibles(responsibleUser, 'username', responsibleUser.profile);
+            }
+            data.options.push({optionId: responsibleId, optionText: responsibleUser.fullname});
+        });
+        Blaze.renderWithData(Template['optionsElement'], data, document.getElementById('id_selResponsibleActionItem'));
     }
     selectResponsibles.trigger('change');
 }

--- a/client/templates/topic/topicInfoItemEdit.js
+++ b/client/templates/topic/topicInfoItemEdit.js
@@ -96,9 +96,7 @@ function configureSelect2Responsibles() {
     let selectResponsibles = $('#id_selResponsibleActionItem');
     selectResponsibles.find('optgroup')     // clear all <option>s
         .remove();
-    let delayTime = 50;
-    if (Meteor.settings.public.isEnd2EndTest)
-        delayTime = 0;
+    let delayTime = Meteor.settings.public.isEnd2EndTest ? 0 : 50;
 
     selectResponsibles.select2({
         placeholder: 'Select...',
@@ -119,7 +117,7 @@ function configureSelect2Responsibles() {
                 let results_participants = [];
                 let results_other = [];
                 _.each(data.results, function (result) {
-                    if (result.isParticipant === true) {
+                    if (result.isParticipant) {
                         results_participants.push({
                             id: result.userId,
                             text: result.fullname

--- a/client/templates/topic/topicInfoItemEdit.js
+++ b/client/templates/topic/topicInfoItemEdit.js
@@ -23,8 +23,7 @@ import { _ } from 'meteor/underscore';
 import { ReactiveVar } from 'meteor/reactive-var';
 import { handleError } from '/client/helpers/handleError';
 import {LabelExtractor} from '../../../imports/services/labelExtractor';
-import {select2search} from '/imports/client/ResponsibleSearch';
-import {addResponsibleOptions} from '/imports/client/ResponsibleSearch';
+import {configureSelect2Responsibles} from '/imports/client/ResponsibleSearch';
 
 Session.setDefault('topicInfoItemEditTopicId', null);
 Session.setDefault('topicInfoItemEditInfoItemId', null);
@@ -78,11 +77,11 @@ let getEditInfoItem = function() {
 let toggleItemMode = function (type, tmpl) {
     let actionItemOnlyElements = tmpl.$('.actionItemOnly');
     Session.set('topicInfoItemType', type);
-
+    let editItem = getEditInfoItem();
     switch (type) {
     case 'actionItem':
         actionItemOnlyElements.show();
-        configureSelect2Responsibles();
+        configureSelect2Responsibles('id_selResponsibleActionItem', editItem._infoItemDoc, false, _minutesID);
         break;
     case 'infoItem':
         actionItemOnlyElements.hide();
@@ -92,18 +91,6 @@ let toggleItemMode = function (type, tmpl) {
         throw new Meteor.Error('Unknown type!');
     }
 };
-
-function configureSelect2Responsibles() {
-    let selectResponsibles = $('#id_selResponsibleActionItem');
-    selectResponsibles.find('option')     // clear all <option>s
-        .remove();
-    let delayTime = Meteor.settings.public.isEnd2EndTest ? 0 : 50;
-
-    select2search(selectResponsibles, delayTime, false, _minutesID);
-    let editItem = getEditInfoItem();
-    addResponsibleOptions('id_selResponsibleActionItem', editItem._infoItemDoc);
-    selectResponsibles.trigger('change');
-}
 
 function configureSelect2Labels() {
     let aMin = new Minutes(_minutesID);
@@ -284,7 +271,7 @@ Template.topicInfoItemEdit.events({
             let type = (editItem instanceof ActionItem) ? 'actionItem' : 'infoItem';
             toggleItemMode(type, tmpl);
         } else {  // adding a new item
-            configureSelect2Responsibles();
+            configureSelect2Responsibles('id_selResponsibleActionItem', editItem._infoItemDoc, false, _minutesID);
             let selectResponsibles = $('#id_selResponsibleActionItem');
             if (selectResponsibles) {
                 selectResponsibles.val([]).trigger('change');

--- a/imports/client/ResponsibleSearch.js
+++ b/imports/client/ResponsibleSearch.js
@@ -1,6 +1,8 @@
 import { Meteor } from 'meteor/meteor';
 import { _ } from 'meteor/underscore';
 import { Minutes } from '/imports/minutes';
+import { Template } from 'meteor/templating';
+import { Blaze } from 'meteor/blaze';
 
 export function select2search(selectResponsibles, delayTime, freeTextValidator, minuteID) {
     selectResponsibles.select2({

--- a/imports/client/ResponsibleSearch.js
+++ b/imports/client/ResponsibleSearch.js
@@ -1,3 +1,6 @@
+import { Meteor } from 'meteor/meteor';
+import { _ } from 'meteor/underscore';
+
 export function select2search(selectResponsibles, delayTime, freeTextValidator, minuteID) {
     selectResponsibles.select2({
         placeholder: 'Select...',

--- a/imports/client/ResponsibleSearch.js
+++ b/imports/client/ResponsibleSearch.js
@@ -1,0 +1,44 @@
+export function select2search(selectResponsibles, delayTime, freeTextValidator, minuteID) {
+    selectResponsibles.select2({
+        placeholder: 'Select...',
+        tags: true,                     // Allow freetext adding
+        tokenSeparators: [',', ';'],
+        ajax: {
+            delay: delayTime,
+            transport: function(params, success, failure) {
+                Meteor.call('responsiblesSearch', params.data.q, minuteID, freeTextValidator, function(err, results) {
+                    if (err) {
+                        failure(err);
+                        return;
+                    }
+                    success(results);
+                });
+            },
+            processResults: function(data) {
+                let results_participants = [];
+                let results_other = [];
+                _.each(data.results, function (result) {
+                    if (result.isParticipant) {
+                        results_participants.push({
+                            id: result.userId,
+                            text: result.fullname
+                        });
+                    }
+                    else results_other.push({
+                        id: result._id,
+                        text: result.fullname
+                    });
+                });
+                // save the return value (when participants/other user are empty -> do not show a group-name
+                let returnValues = [];
+                if (results_participants.length > 0)
+                    returnValues.push({text:'Participants', children: results_participants});
+                if (results_other.length > 0)
+                    returnValues.push({text:'Other Users', children: results_other});
+
+                return {
+                    results:returnValues
+                };
+            }}
+    });
+}

--- a/imports/client/ResponsibleSearch.js
+++ b/imports/client/ResponsibleSearch.js
@@ -3,6 +3,7 @@ import { _ } from 'meteor/underscore';
 import { Minutes } from '/imports/minutes';
 import { Template } from 'meteor/templating';
 import { Blaze } from 'meteor/blaze';
+import { $ } from 'meteor/jquery';
 
 function select2search(selectResponsibles, delayTime, freeTextValidator, minuteID) {
     selectResponsibles.select2({

--- a/imports/client/ResponsibleSearch.js
+++ b/imports/client/ResponsibleSearch.js
@@ -4,7 +4,7 @@ import { Minutes } from '/imports/minutes';
 import { Template } from 'meteor/templating';
 import { Blaze } from 'meteor/blaze';
 
-export function select2search(selectResponsibles, delayTime, freeTextValidator, minuteID) {
+function select2search(selectResponsibles, delayTime, freeTextValidator, minuteID) {
     selectResponsibles.select2({
         placeholder: 'Select...',
         tags: true,                     // Allow freetext adding
@@ -49,7 +49,13 @@ export function select2search(selectResponsibles, delayTime, freeTextValidator, 
     });
 }
 
-export function addResponsibleOptions(SelectResponsibleElementID, topicOrItemDoc){
+export function configureSelect2Responsibles(SelectResponsibleElementID, topicOrItemDoc, freeTextValidator, _minutesID) {
+    let selectResponsibles = $('#'+SelectResponsibleElementID);
+    selectResponsibles.find('option')     // clear all <option>s
+        .remove();
+    let delayTime = Meteor.settings.public.isEnd2EndTest ? 0 : 50;
+
+    select2search(selectResponsibles, delayTime, freeTextValidator, _minutesID);
     let data = {options: []};
     if (topicOrItemDoc !== undefined) {
         topicOrItemDoc.responsibles.forEach(responsibleId => {
@@ -63,4 +69,5 @@ export function addResponsibleOptions(SelectResponsibleElementID, topicOrItemDoc
         });
         Blaze.renderWithData(Template['optionsElement'], data, document.getElementById(SelectResponsibleElementID));
     }
+    selectResponsibles.trigger('change');
 }

--- a/imports/client/ResponsibleSearch.js
+++ b/imports/client/ResponsibleSearch.js
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { _ } from 'meteor/underscore';
+import { Minutes } from '/imports/minutes';
 
 export function select2search(selectResponsibles, delayTime, freeTextValidator, minuteID) {
     selectResponsibles.select2({
@@ -44,4 +45,20 @@ export function select2search(selectResponsibles, delayTime, freeTextValidator, 
                 };
             }}
     });
+}
+
+export function addResponsibleOptions(SelectResponsibleElementID, topicOrItemDoc){
+    let data = {options: []};
+    if (topicOrItemDoc !== undefined) {
+        topicOrItemDoc.responsibles.forEach(responsibleId => {
+            let responsibleUser = Meteor.users.findOne(responsibleId);
+            if (!responsibleUser) { //free text user
+                responsibleUser = {fullname: responsibleId};
+            } else {
+                Minutes.formatResponsibles(responsibleUser, 'username', responsibleUser.profile);
+            }
+            data.options.push({optionId: responsibleId, optionText: responsibleUser.fullname});
+        });
+        Blaze.renderWithData(Template['optionsElement'], data, document.getElementById(SelectResponsibleElementID));
+    }
 }

--- a/imports/collections/minutes_private.js
+++ b/imports/collections/minutes_private.js
@@ -243,7 +243,7 @@ Meteor.methods({
         let foundPartipantsNames = [];
         let allPartipantsNames = [];
 
-        if (participantsAdditional) {
+        if (participantsAdditional && freeTextValidator) {
             participantsAdditional.split(/[,;]/).forEach(freeText => {
                 participants.push({name: freeText.trim(), userId:freeText.trim()});
             });
@@ -290,15 +290,16 @@ Meteor.methods({
                 limit: 10 + results_participants.length, //we want to show 10 "Other user"
                 // as it is not known, if a user a participant or not -> get 10+participants
                 fields: searchFields
-        }).fetch();
+            }
+        ).fetch();
 
         results_otherUser = results_otherUser.filter(user => { //remove duplicates
             return !(foundPartipantsNames.includes(user.username));
         });
         results_otherUser = results_otherUser.slice(0,10); // limit to 10 records
 
-        results_otherUser.forEach( otherUser => {
-            otherUser = minute.formatResponsibles(otherUser, 'username', GlobalSettings.isTrustedIntranetInstallation());
+        results_otherUser = results_otherUser.map(otherUser => {
+            return minute.formatResponsibles(otherUser, 'username', GlobalSettings.isTrustedIntranetInstallation());
         });
 
         return {

--- a/imports/collections/minutes_private.js
+++ b/imports/collections/minutes_private.js
@@ -249,7 +249,7 @@ Meteor.methods({
             });
         }
         participants.forEach( participant =>{
-            participant = minute.formatResponsibles(participant,'name', true);
+            participant = Minutes.formatResponsibles(participant,'name', true);
             if (participant.fullname.toLowerCase().includes(partialName.toLowerCase())) {
                 participant['isParticipant'] = true;
                 results_participants.push(participant);
@@ -299,7 +299,7 @@ Meteor.methods({
         results_otherUser = results_otherUser.slice(0,10); // limit to 10 records
 
         results_otherUser = results_otherUser.map(otherUser => {
-            return minute.formatResponsibles(otherUser, 'username', GlobalSettings.isTrustedIntranetInstallation());
+            return Minutes.formatResponsibles(otherUser, 'username', GlobalSettings.isTrustedIntranetInstallation());
         });
 
         return {

--- a/imports/collections/minutes_private.js
+++ b/imports/collections/minutes_private.js
@@ -275,8 +275,8 @@ Meteor.methods({
         let searchSettings = {username: {'$regex': partialName, '$options': 'i'}};
         let searchFields = {_id: 1, username: 1};
         if (GlobalSettings.isTrustedIntranetInstallation()){
-            searchSettings = {$or :
-                [
+            searchSettings = {
+                $or : [
                     {username: {'$regex': partialName, '$options': 'i'}},
                     {'profile.name': {'$regex': partialName, '$options': 'i'}}
                 ]

--- a/imports/collections/minutes_private.js
+++ b/imports/collections/minutes_private.js
@@ -230,5 +230,26 @@ Meteor.methods({
         } else {
             throw new Meteor.Error('Cannot sync visibility of minutes', 'You are not moderator of the parent meeting series.');
         }
+    },
+
+    'respSearch' (partialName) {
+        check(partialName, String);
+
+        var results = Meteor.users.find({
+            username: {
+                '$regex': '^' + partialName,
+                '$options': 'i'
+            }
+        }, {
+            limit: 10,
+            fields: {
+                _id: 1,
+                username: 1
+            }
+        }).fetch();
+
+        return {
+            results: results
+        };
     }
 });

--- a/imports/collections/minutes_private.js
+++ b/imports/collections/minutes_private.js
@@ -232,24 +232,63 @@ Meteor.methods({
         }
     },
 
-    'respSearch' (partialName) {
+    'respSearch' (partialName, minuteID) {
         check(partialName, String);
+        let minute = new Minutes(minuteID);
+        let participants = minute.getParticipants(Meteor.users);
 
-        var results = Meteor.users.find({
+        let results_participants = []; // get all the participants for the minute
+        participants.forEach( participant =>{
+            if (participant.name.startsWith(partialName)) {
+                participant['isParticipant'] = true;
+                results_participants.push(participant);
+            }
+        });
+
+        let results_otherUser = Meteor.users.find({ // find other user
             username: {
                 '$regex': '^' + partialName,
                 '$options': 'i'
             }
         }, {
-            limit: 10,
+            limit: 10+results_participants.length, //we want to show 10 "Other user"
+                                                    // as it is not known, is a user a participant or not -> get 10+participants
             fields: {
                 _id: 1,
                 username: 1
             }
         }).fetch();
 
+        let foundUser_final = [];
+
+        results_otherUser.forEach(otherUser => {
+            otherUser['isDuplicate'] = false;}
+        );
+
+        if (results_participants.length !== 0) { // check if "other user" already in participants list
+            results_otherUser.forEach(otherUser => {
+                results_participants.forEach(participant => {
+                    if (otherUser.username == participant.name)
+                        otherUser['isDuplicate'] = true;
+                })
+            });
+        }
+
+        results_participants.forEach(participant => { // push all the participants to result
+            foundUser_final.push(participant);
+        });
+
+        results_otherUser.forEach(otherUser =>{ //push only "not duplicates" from other user and max. 10
+            if (foundUser_final.length == (results_participants.length + 10))
+                return;
+            else if (otherUser.isDuplicate == false) {
+                otherUser['isParticipant'] = false;
+                foundUser_final.push(otherUser);
+            }
+        });
+
         return {
-            results: results
+            results: foundUser_final
         };
     }
 });

--- a/imports/minutes.js
+++ b/imports/minutes.js
@@ -466,7 +466,7 @@ export class Minutes {
     }
 
     formatResponsibles(responsible, usernameField, isProfileAvaliable) {
-        if (isProfileAvaliable && responsible.profile && responsible.profile.name && responsible.profile.name !== '') {
+        if (isProfileAvaliable && responsible.profile && responsible.profile.name) {
             responsible.fullname = responsible[usernameField] +` - ${responsible.profile.name}`;
         }
         else {

--- a/imports/minutes.js
+++ b/imports/minutes.js
@@ -465,7 +465,7 @@ export class Minutes {
         return subElementsHelper.findIndexById(id, this.topics);
     }
 
-    formatResponsibles(responsible, usernameField, isProfileAvaliable) {
+    static formatResponsibles(responsible, usernameField, isProfileAvaliable) {
         if (isProfileAvaliable && responsible.profile && responsible.profile.name) {
             responsible.fullname = responsible[usernameField] +` - ${responsible.profile.name}`;
         }

--- a/imports/minutes.js
+++ b/imports/minutes.js
@@ -384,6 +384,7 @@ export class Minutes {
             return this.participants.map(participant => {
                 let user = userCollection.findOne(participant.userId);
                 participant.name = user.username;
+                participant.profile = user.profile;
                 return participant;
             });
         }

--- a/imports/minutes.js
+++ b/imports/minutes.js
@@ -464,4 +464,15 @@ export class Minutes {
     _findTopicIndex(id) {
         return subElementsHelper.findIndexById(id, this.topics);
     }
+
+    formatResponsibles(responsible, usernameField, isProfileAvaliable) {
+        if (isProfileAvaliable && responsible.profile && responsible.profile.name && responsible.profile.name !== '') {
+            responsible.fullname = responsible[usernameField] +` - ${responsible.profile.name}`;
+        }
+        else {
+            responsible.fullname = responsible[usernameField];
+        }
+        return responsible;
+    }
+
 }

--- a/tests/end2end/TopicsResponsibles-test.js
+++ b/tests/end2end/TopicsResponsibles-test.js
@@ -96,7 +96,9 @@ describe('Topics Responsibles', function () {
         E2ETopics.openEditTopicForMinutes(1);
         E2EGlobal.waitSomeTime();
         browser.element(".form-group-responsibles .select2-selection").click();
-        browser.keys("3\uE015\uE007");  // "3" (end of user3 string) + CursorDown + Enter
+        browser.keys("3");
+        E2EGlobal.waitSomeTime();
+        browser.keys("\uE015\uE007");  // "3" (end of user3 string) + CursorDown + Enter
         E2EGlobal.waitSomeTime();
         E2EGlobal.clickWithRetry("#btnTopicSave");
         E2EGlobal.waitSomeTime(500);

--- a/tests/end2end/helpers/E2ETopics.js
+++ b/tests/end2end/helpers/E2ETopics.js
@@ -78,7 +78,9 @@ export class E2ETopics {
     static responsible2TopicEnterFreetext(theText) {
         browser.element('#id_subject').click();
         browser.keys("\uE004\uE004"); // Tab to reach next input field => labels
-        browser.keys(theText+"\uE007"); // plus ENTER
+        browser.keys(theText);
+        E2EGlobal.waitSomeTime();
+        browser.keys("\uE007"); // plus ENTER
     }
 
     static labelEnterFreetext(theText) {


### PR DESCRIPTION
1. Made perfomance tests for typeahead and select2 with 1000/5000/10000 and 50000 users. Typeahead works fast with large amounts of data. Select2 was already going slow with 5000 users. 
Adding new user to a DB was done with a following method:
``` 
'users.createUsers'(name, numberOfUsers) {
        console.log('-------------------------- METHOD: createUsers ');  
        for (let i = 1; i < numberOfUsers; i++) {  
            let newUser = name + i;  
            let newPassword = 'Password' +i;  
            let newEmail = 't@test' + newUser + '.de';  
            Accounts.createUser({username: newUser, password: newPassword, email: newEmail});              
            Meteor.users.update({'username': newUser}, {$set: {'emails.0.verified': true}});  
            console.log('Created user: ' + newUser + ' with password: ' + newPassword);  
    }  
}  
```

2. Performance of select2 was increased by searching data remote. Made tests with 5000 / 10000 and 15 000 users => works amazing