### PR TITLE
Subscribe meetingSeriesOverview on home-view - fixes #362

### DIFF
--- a/client/templates/home.html
+++ b/client/templates/home.html
@@ -1,6 +1,7 @@
 <template name="home">
-
-    {{#if currentUser}}
+    {{#if authenticating}}
+        {{> loading}}
+    {{else}}
         <ul class="nav nav-tabs">
             <li id="tab_meetings" data-template="meetingSeriesList" role="presentation" class="{{isTabActive 'tab_meetings'}}"><a>Meetings</a></li>
             <li id="tab_actionItems" data-template="actionItemList" data-action="actionItems" role="presentation" class="{{isTabActive 'tab_actionItems'}}"><a>Action Items</a></li>
@@ -8,12 +9,6 @@
         <div class="active">
             {{> Template.dynamic template=tab}}
         </div>
-    {{else}}
-
-      <!-- This login template embedding is for security only... -->
-      <!-- Normally the router.js decides to render the login template if no user is logged in -->
-      {{> login}}
-
     {{/if}}
 
 </template>

--- a/client/templates/home.js
+++ b/client/templates/home.js
@@ -1,3 +1,4 @@
+import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 import { $ } from 'meteor/jquery';
 import { ReactiveVar } from 'meteor/reactive-var';
@@ -10,9 +11,18 @@ Template.home.created = function () {
 Template.home.onCreated(function () {
     this.activeTabTemplate = new ReactiveVar('meetingSeriesList');
     this.activeTabId = new ReactiveVar('tab_meetings');
+    this.seriesReady = new ReactiveVar();
+    this.autorun(() => {
+        this.subscribe('meetingSeriesOverview');
+        this.seriesReady.set(this.subscriptionsReady());
+    });
 });
 
 Template.home.helpers({
+    authenticating() {
+        const subscriptionReady = Template.instance().seriesReady.get();
+        return Meteor.loggingIn() || !subscriptionReady;
+    },
     isTabActive: function (tabId) {
         return (Template.instance().activeTabId.get() === tabId) ? 'active' : '';
     },

--- a/client/templates/meetingseries/meetingSeriesList.html
+++ b/client/templates/meetingseries/meetingSeriesList.html
@@ -1,24 +1,20 @@
 <template name="meetingSeriesList">
-    {{#if authenticating}}
-        {{> loading}}
-    {{else}}
-        {{> meetingSeriesAdd}}
-        {{#if meetingSeriesAmountBiggerFour}}
-            {{> meetingSeriesSearch updateSearchQuery=updateSearchQuery}}
-        {{/if}}
-        <br>
-        <br>
-
-        <ul class="list-group" style="font-size: 130%;">
-            {{#if meetingSeriesRow}}
-                {{#each meetingSeriesRow}}
-                    {{> meetingSeriesOverview}}
-                {{/each}}
-            {{else}}
-                <span id="id_noresults">No Results for this input..</span>
-            {{/if}}
-        </ul>
-
-        {{> quickHelp context='meetingSeriesList' contentTmpl='quickHelpMeetingSeriesList'}}
+    {{> meetingSeriesAdd}}
+    {{#if meetingSeriesAmountBiggerFour}}
+        {{> meetingSeriesSearch updateSearchQuery=updateSearchQuery}}
     {{/if}}
+    <br>
+    <br>
+
+    <ul class="list-group" style="font-size: 130%;">
+        {{#if meetingSeriesRow}}
+            {{#each meetingSeriesRow}}
+                {{> meetingSeriesOverview}}
+            {{/each}}
+        {{else}}
+            <span id="id_noresults">No Results for this input..</span>
+        {{/if}}
+    </ul>
+
+    {{> quickHelp context='meetingSeriesList' contentTmpl='quickHelpMeetingSeriesList'}}
 </template>

--- a/client/templates/meetingseries/meetingSeriesList.js
+++ b/client/templates/meetingseries/meetingSeriesList.js
@@ -1,4 +1,3 @@
-import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 import { MeetingSeries } from '/imports/meetingseries';
 import { ReactiveVar } from 'meteor/reactive-var';
@@ -16,19 +15,10 @@ function getFilteredSeries(queryString) {
 }
 
 Template.meetingSeriesList.onCreated(function () {
-    this.seriesReady = new ReactiveVar();
     this.searchQuery = new ReactiveVar('');
-    this.autorun(() => {
-        this.subscribe('meetingSeriesOverview');
-        this.seriesReady.set(this.subscriptionsReady());
-    });
 });
 
 Template.meetingSeriesList.helpers({
-    authenticating() {
-        const subscriptionReady = Template.instance().seriesReady.get();
-        return Meteor.loggingIn() || !subscriptionReady;
-    },
     meetingSeriesRow() {
         const searchQuery = Template.instance().searchQuery.get();
 

--- a/imports/collections/meetingseries_private.js
+++ b/imports/collections/meetingseries_private.js
@@ -20,7 +20,8 @@ if (Meteor.isServer) {
                     'minutes' : 1,
                     'lastMinutesDate' : 1,
                     'lastMinutesFinalized' : 1,
-                    'lastMinutesId' : 1
+                    'lastMinutesId' : 1,
+                    'availableLabels' : 1
                 }
             }
         );


### PR DESCRIPTION
Since we need to access the meeting series on both tabs (Meeting Series List and Action Items Tab) which are hold by the home-view, I moved the subscription to the parent view. Additionally, I adjusted the `meetingSeriesOverview`-publication to pass the `availableLabels`, too. They are required to show the labels of the action items in the Action Items Tab.