### PR TITLE
Check if infoItem is undefined before trying to change it

### DIFF
--- a/client/templates/topic/topicEdit.js
+++ b/client/templates/topic/topicEdit.js
@@ -67,7 +67,9 @@ function configureSelect2Labels() {
 
 function closePopupAndUnsetIsEdited() {
     const topic = getEditTopic();
-    IsEditedService.removeIsEditedTopic(_minutesID, topic._topicDoc._id, false);
+    if (typeof topic !== 'undefined') {
+        IsEditedService.removeIsEditedTopic(_minutesID, topic._topicDoc._id, false);
+    }
 
     $('#dlgAddTopic').modal('hide');
 }

--- a/imports/services/isEditedService.js
+++ b/imports/services/isEditedService.js
@@ -123,23 +123,24 @@ function removeIsEditedInfoItem(minutesId, topicId, infoItemId, ignoreLock) {
     let topic = new Topic(minutesId, topicId);
     let infoItem = topic.findInfoItem(infoItemId);
 
-    if (typeof infoItem !== 'undefined' ) {
-        if (ignoreLock === true) {
+    if (typeof infoItem === 'undefined' ) {
+        return;
+    }
+    
+    if (ignoreLock === true) {
+        unset = true;
+    }
+    else {
+        if (infoItem._infoItemDoc.isEditedBy === Meteor.userId()) {
             unset = true;
-        }
-        else {
-            if (infoItem._infoItemDoc.isEditedBy === Meteor.userId()) {
-                unset = true;
-            }
-        }
-
-        if (unset === true) {
-            infoItem._infoItemDoc.isEditedBy = null;
-            infoItem._infoItemDoc.isEditedDate = null;
-            infoItem.save();
         }
     }
 
+    if (unset === true) {
+        infoItem._infoItemDoc.isEditedBy = null;
+        infoItem._infoItemDoc.isEditedDate = null;
+        infoItem.save();
+    }
 }
 
 function setIsEditedDetail(minutesId, topicId, infoItemId, detailIdx) {
@@ -157,24 +158,24 @@ function removeIsEditedDetail(minutesId, topicId, infoItemId, detailIdx, ignoreL
     let topic = new Topic(minutesId, topicId);
     let infoItem = topic.findInfoItem(infoItemId);
 
-    if (typeof infoItem !== 'undefined' ) {
-        if (ignoreLock === true) {
+    if (typeof infoItem === 'undefined' ) {
+        return;
+    }
+    
+    if (ignoreLock === true) {
+        unset = true;
+    }
+    else {
+        if (infoItem._infoItemDoc.details[detailIdx].isEditedBy === Meteor.userId()) {
             unset = true;
-        }
-        else {
-            if (infoItem._infoItemDoc.details[detailIdx].isEditedBy === Meteor.userId()) {
-                unset = true;
-            }
-        }
-
-        if(unset === true) {
-            infoItem._infoItemDoc.details[detailIdx].isEditedBy = null;
-            infoItem._infoItemDoc.details[detailIdx].isEditedDate = null;
-            infoItem.save();
         }
     }
 
-
+    if(unset === true) {
+        infoItem._infoItemDoc.details[detailIdx].isEditedBy = null;
+        infoItem._infoItemDoc.details[detailIdx].isEditedDate = null;
+        infoItem.save();
+    }
 }
 
 Meteor.methods({

--- a/imports/services/isEditedService.js
+++ b/imports/services/isEditedService.js
@@ -123,21 +123,22 @@ function removeIsEditedInfoItem(minutesId, topicId, infoItemId, ignoreLock) {
     let topic = new Topic(minutesId, topicId);
     let infoItem = topic.findInfoItem(infoItemId);
 
-    if (ignoreLock === true) {
-        unset = true;
-    }
-    else {
-        if (infoItem._infoItemDoc.isEditedBy === Meteor.userId()) {
+    if (typeof infoItem !== 'undefined' ) {
+        if (ignoreLock === true) {
             unset = true;
         }
-    }
+        else {
+            if (infoItem._infoItemDoc.isEditedBy === Meteor.userId()) {
+                unset = true;
+            }
+        }
 
-    if (unset === true) {
-        infoItem._infoItemDoc.isEditedBy = null;
-        infoItem._infoItemDoc.isEditedDate = null;
-        infoItem.save();
+        if (unset === true) {
+            infoItem._infoItemDoc.isEditedBy = null;
+            infoItem._infoItemDoc.isEditedDate = null;
+            infoItem.save();
+        }
     }
-
 
 }
 
@@ -156,19 +157,21 @@ function removeIsEditedDetail(minutesId, topicId, infoItemId, detailIdx, ignoreL
     let topic = new Topic(minutesId, topicId);
     let infoItem = topic.findInfoItem(infoItemId);
 
-    if (ignoreLock === true) {
-        unset = true;
-    }
-    else {
-        if (infoItem._infoItemDoc.details[detailIdx].isEditedBy === Meteor.userId()) {
+    if (typeof infoItem !== 'undefined' ) {
+        if (ignoreLock === true) {
             unset = true;
         }
-    }
+        else {
+            if (infoItem._infoItemDoc.details[detailIdx].isEditedBy === Meteor.userId()) {
+                unset = true;
+            }
+        }
 
-    if(unset === true) {
-        infoItem._infoItemDoc.details[detailIdx].isEditedBy = null;
-        infoItem._infoItemDoc.details[detailIdx].isEditedDate = null;
-        infoItem.save();
+        if(unset === true) {
+            infoItem._infoItemDoc.details[detailIdx].isEditedBy = null;
+            infoItem._infoItemDoc.details[detailIdx].isEditedDate = null;
+            infoItem.save();
+        }
     }
 
 


### PR DESCRIPTION
If the modal dialog for creating a new info/action item is canceled, the following exception is thrown:

```
I20191030-10:01:23.224(1)? Exception while invoking method 'workflow.removeIsEditedInfoItem' TypeError: Cannot read property '_infoItemDoc' of undefined
I20191030-10:01:23.229(1)?     at removeIsEditedInfoItem (imports/services/isEditedService.js:130:22)
I20191030-10:01:23.230(1)?     at MethodInvocation.workflow.removeIsEditedInfoItem (imports/services/isEditedService.js:204:9)
I20191030-10:01:23.230(1)?     at maybeAuditArgumentChecks (packages/ddp-server/livedata_server.js:1768:12)
I20191030-10:01:23.230(1)?     at DDP._CurrentMethodInvocation.withValue (packages/ddp-server/livedata_server.js:719:19)
I20191030-10:01:23.231(1)?     at Meteor.EnvironmentVariable.EVp.withValue (packages/meteor.js:1186:15)
I20191030-10:01:23.231(1)?     at DDPServer._CurrentWriteFence.withValue (packages/ddp-server/livedata_server.js:717:46)
I20191030-10:01:23.231(1)?     at Meteor.EnvironmentVariable.EVp.withValue (packages/meteor.js:1186:15)
I20191030-10:01:23.232(1)?     at Promise (packages/ddp-server/livedata_server.js:715:46)
I20191030-10:01:23.232(1)?     at new Promise (<anonymous>)
I20191030-10:01:23.232(1)?     at Session.method (packages/ddp-server/livedata_server.js:689:23)
I20191030-10:01:23.233(1)?     at packages/ddp-server/livedata_server.js:559:43
```

This PR adds a check on whether or not infoItem is defined before trying to set 
```
infoItem._infoItemDoc.isEditedBy = null;
infoItem._infoItemDoc.isEditedDate = null;
```