### PR TITLE
Set a higher timeout for Travis apt-get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,6 @@ addons:
       - ./server.log
       - ./client.log
       - $(ls ./versions/* | tr "\n" ":")
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
 
 #cache:
 #  directories:
@@ -45,6 +40,9 @@ node_js:
   - "8.9.4"
 
 before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -q --option Acquire::Retries=100 --option Acquire::http::Timeout="300"
+  - sudo apt-get install gcc-4.8 -y --option Acquire::Retries=100 --option Acquire::http::Timeout="300"
   - curl https://install.meteor.com | /bin/sh
   - npm install -g chimp@0.51.1
 


### PR DESCRIPTION
The Travis builds are failing due to apt-get running into a timeout. This seems to be a common problem which can be fixed by setting a higher timeout. For this, the APT addon must be changed in favor of three manual before_install apt-get calls.