### PR TITLE
Update admin guide to working instructions

### DIFF
--- a/doc/admin/adminguide.md
+++ b/doc/admin/adminguide.md
@@ -228,7 +228,7 @@ to be able to build the sources in a runnable server, first install the current
 version of the meteor build tool:
 
 ```sh
-curl https://install.meteor.com/ | sh
+curl https://install.meteor.com/?release=1.6 | sh
 meteor --version
 ```
 
@@ -300,6 +300,7 @@ cp settings_sample.json ../4minitz_bin/bundle/settings.json
 
 cd ../4minitz_bin/bundle/programs/server
 meteor npm install --production
+meteor npm install @babel/runtime@7.0.0-beta.55
 
 cd ../..
 nano settings.json

--- a/doc/admin/adminguide.md
+++ b/doc/admin/adminguide.md
@@ -319,7 +319,7 @@ export ROOT_URL='http://4minitz.example.com:61405'
 export METEOR_SETTINGS=$(cat ./settings.json)
 ```
 
-Now, inside the `/4minitz_bin/bundle/programs/server` directory, you must launch
+Now, inside the `/4minitz_bin/bundle` directory, you must launch
 the 4Minitz server:
 
 ```sh


### PR DESCRIPTION
With the following update to admin guide, the instructions now lead to a workable installation:
* Use meteor 1.6.
* install babel runtime 7.0.0-beta.55 as per [this forum's solution](https://forums.meteor.com/t/solved-cannot-find-module-babel-runtime-helpers-builtin-objectspread-after-update-meteor-to-1-6-1-1/43034/11).
* Run the meteor inside `4minitz_bin/bundle` folder where `main.js` exists instead of `/4minitz_bin/bundle/programs/server`.