### PR TITLE
Split moderator's UI language from Meeting Minute doc's language (solves #540)

### DIFF
--- a/both/i18n/en.i18n.yml
+++ b/both/i18n/en.i18n.yml
@@ -106,6 +106,7 @@ Dialog:
     title: "Set Language"
     languageLocale: "Language Locale"
     automatic: "Automatic via Browser"
+    contributionHintMT: "(*) marks machine-translated languages. Help needed."
     contributionHint1: "Translation mistakes or missing language?"
     contributionHint2: "Help us to translate 4Minitz!"
   IsEditedHandling:

--- a/both/i18n/en.i18n.yml
+++ b/both/i18n/en.i18n.yml
@@ -100,6 +100,8 @@ Dialog:
     really: "Do you really want to finalize this meeting minute dated on **{$minutesDate}**?"
     sendActionItems: "Send action items"
     sendMinutes: "Send information items"
+    eMailLanguage: "E-Mail Language:"
+    eMailLanguageHint: "Hint: You may configure the E-Mail language in the settings of the Meeting Series"
   LocaleSetting:
     title: "Set Language"
     languageLocale: "Language Locale"
@@ -365,6 +367,7 @@ MeetingSeries:
     labels: "Labels"
     save: "Save Meeting Series"
     confirmDelete: "Confirm delete"
+    languageLocale: "Language for Meeting Series E-Mails (Agenda, Minutes, ...)"
   Labels:
     Error:
       name: "Please enter a valid label name"

--- a/client/templates/globals/localeDialog.html
+++ b/client/templates/globals/localeDialog.html
@@ -9,7 +9,7 @@
                 <form id="frmDlgSetLocale">
                     <div class="modal-body">
                         <div class="form-group ">
-                            <label for="id_longName" class="control-label">{{__ 'Dialog.LocaleSetting.languageLocale' }}</label>
+                            <label for="selLocale" class="control-label">{{__ 'Dialog.LocaleSetting.languageLocale' }}</label>
 
                             <select id="selLocale" class="form-control">
                                 <option id="loc-auto" value="auto">

--- a/client/templates/globals/localeDialog.html
+++ b/client/templates/globals/localeDialog.html
@@ -17,8 +17,9 @@
                                 </option>
                                 {{#each locale in supportedLocales}}
                                     <option id="loc-{{locale.code}}" value="{{locale.code}}">
+                                        {{#unless locale.approved}}(*){{/unless}}
                                         {{locale.nameNative}} ({{locale.codeUI}})
-                                    </option>
+                                        </option>
                                 {{/each}}
                             </select>
                         </div>
@@ -29,10 +30,11 @@
                     </div>
                 </form>
                 <p style="text-align: center; padding-top: 1em; padding-bottom: .5em;">
-                {{__ 'Dialog.LocaleSetting.contributionHint1'}}
-                <a href="https://crowdin.com/project/4minitz" target="_blank">
-                    {{__ 'Dialog.LocaleSetting.contributionHint2'}}
-                </a>
+                    {{__ 'Dialog.LocaleSetting.contributionHintMT'}}<br>
+                    {{__ 'Dialog.LocaleSetting.contributionHint1'}}
+                    <a href="https://crowdin.com/project/4minitz" target="_blank">
+                        {{__ 'Dialog.LocaleSetting.contributionHint2'}}
+                    </a>
                 </p>
             </div>
         </div>

--- a/client/templates/globals/localeDialog.js
+++ b/client/templates/globals/localeDialog.js
@@ -37,17 +37,19 @@ Template.localeDialog.events({
     'show.bs.modal #dlgLocale': function (evt, tmpl) {
         // preselect the current locale, if user is logged in
         let locID = '#loc-' + I18nHelper.getLanguageLocale();       // might be 'en-US'
-        const select = tmpl.find(locID);
+        let select = tmpl.find(locID);
+        if (!select) {
+            locID = '#loc-' + I18nHelper.getLanguageLocale().substr(0,2);   // fallback: try first two letters: 'en-US' => 'en'
+            select = tmpl.find(locID);
+        }
+        if (!select) {
+            select = tmpl.find('#loc-en');
+        }
+
         if (select) {
             select.selected = true;
         } else {
-            locID = '#loc-' + I18nHelper.getLanguageLocale().substr(0,2);   // fallback: try 'en'
-            const select = tmpl.find(locID);
-            if (select) {
-                select.selected = true;
-            } else {
-                console.log('Could not find select option: >'+ locID+'<');
-            }
+            console.log('Could not find select option: >' + locID + '<');
         }
     },
 });

--- a/client/templates/meetingseries/meetingSeriesAdd.js
+++ b/client/templates/meetingseries/meetingSeriesAdd.js
@@ -4,6 +4,7 @@ import { Session } from 'meteor/session';
 import { $ } from 'meteor/jquery';
 import { MeetingSeries } from '/imports/meetingseries';
 import { handleError } from '/client/helpers/handleError';
+import {GlobalSettings} from '../../../imports/config/GlobalSettings';
 
 function clearForm(template) {
     template.find('#id_meetingproject').value = '';
@@ -32,6 +33,7 @@ function addMeetingSeries(template, optimisticUICallback) {
     let ms = new MeetingSeries({
         project: aProject,
         name: aName,
+        mailLanguage: GlobalSettings.getDefaultMeetingSeriesMailLanguage(),
         createdAt: new Date()
     });
 

--- a/client/templates/meetingseries/meetingSeriesEdit.html
+++ b/client/templates/meetingseries/meetingSeriesEdit.html
@@ -41,10 +41,16 @@
                                             <select id="selLocale" class="form-control">
                                                 {{#each locale in supportedLocales}}
                                                     <option id="loc-{{locale.code}}" value="{{locale.code}}">
+                                                        {{#unless locale.approved}}(*){{/unless}}
                                                         {{locale.nameNative}} ({{locale.codeUI}})
                                                     </option>
                                                 {{/each}}
                                             </select>
+                                            {{__ 'Dialog.LocaleSetting.contributionHintMT'}}<br>
+                                            {{__ 'Dialog.LocaleSetting.contributionHint1'}}
+                                            <a href="https://crowdin.com/project/4minitz" target="_blank">
+                                                {{__ 'Dialog.LocaleSetting.contributionHint2'}}
+                                            </a>
 
                                         </div>
                                     </div>

--- a/client/templates/meetingseries/meetingSeriesEdit.html
+++ b/client/templates/meetingseries/meetingSeriesEdit.html
@@ -36,6 +36,16 @@
                                             <label class="control-label" for="id_meetingname">{{__ 'MeetingSeries.Edit.meetingName' }}</label>
                                             <input class="form-control" id="id_meetingname" type="text" value="{{this.name}}" required
                                                    data-error-msg="{{__ 'MeetingSeries.Edit.Error.meetingName' }}" autocomplete="off">
+
+                                            <label for="selLocale" class="control-label">{{__ 'MeetingSeries.Edit.languageLocale' }}</label>
+                                            <select id="selLocale" class="form-control">
+                                                {{#each locale in supportedLocales}}
+                                                    <option id="loc-{{locale.code}}" value="{{locale.code}}">
+                                                        {{locale.nameNative}} ({{locale.code}})
+                                                    </option>
+                                                {{/each}}
+                                            </select>
+
                                         </div>
                                     </div>
                                 </div>

--- a/client/templates/meetingseries/meetingSeriesEdit.html
+++ b/client/templates/meetingseries/meetingSeriesEdit.html
@@ -41,7 +41,7 @@
                                             <select id="selLocale" class="form-control">
                                                 {{#each locale in supportedLocales}}
                                                     <option id="loc-{{locale.code}}" value="{{locale.code}}">
-                                                        {{locale.nameNative}} ({{locale.code}})
+                                                        {{locale.nameNative}} ({{locale.codeUI}})
                                                     </option>
                                                 {{/each}}
                                             </select>

--- a/client/templates/minutes/confirmationDialogFinalize.html
+++ b/client/templates/minutes/confirmationDialogFinalize.html
@@ -12,4 +12,6 @@
             <input id='cbSendII' type='checkbox' class='checkbox' {{sendInformationItems}}> {{__ 'Dialog.ConfirmFinalizeMinutes.sendMinutes' }}
         </label>
     </div>
+    {{__ 'Dialog.ConfirmFinalizeMinutes.eMailLanguage' }} <b>{{mailLanguage}}</b><br>
+    <span style="color: #999999">{{__ 'Dialog.ConfirmFinalizeMinutes.eMailLanguageHint' }}</span>
 </template>

--- a/client/templates/minutes/minutesedit.js
+++ b/client/templates/minutes/minutesedit.js
@@ -35,6 +35,7 @@ let _minutesID; // the ID of these minutes
 let orphanFlashMessage = null;
 
 let filterClosedTopics = new ReactiveVar(false);
+let supportedLocales = new ReactiveVar([]);
 
 /**
  * togglePrintView
@@ -166,6 +167,15 @@ Template.minutesedit.onCreated(function () {
             this.minutesReady.set(this.subscriptionsReady());
         }
     });
+    Meteor.call('getAvailableLocales',
+        function(error, result){
+            if(error){
+                console.log('Error: No supported language locales reported by server.');
+            }else{
+                supportedLocales.set(result);
+            }
+        }
+    );
 
     Session.set('minutesedit.checkParent', false);
     handleTemplatesGlobalKeyboardShortcuts(true);
@@ -581,6 +591,8 @@ Template.minutesedit.events({
     'click #btn_finalizeMinutes': function(evt, tmpl) {
         evt.preventDefault();
         let aMin = new Minutes(_minutesID);
+        let ms = new MeetingSeries(aMin.meetingSeries_id);
+
         console.log('Finalize minutes: ' + aMin._id + ' from series: ' + aMin.meetingSeries_id);
 
         let doFinalize = function () {
@@ -597,6 +609,14 @@ Template.minutesedit.events({
             }, 500);
         };
 
+        let msLanguage = {}; //  //
+        for (let loc of supportedLocales.get()) {
+            if (loc.code === ms.getMailLanguage()) {
+                msLanguage = loc;
+                break;
+            }
+        }
+
         let processFinalize = function(){
             if (GlobalSettings.isEMailDeliveryEnabled()) {
                 ConfirmationDialogFactory.makeSuccessDialogWithTemplate(
@@ -607,7 +627,8 @@ Template.minutesedit.events({
                         minutesDate: aMin.date,
                         hasOpenActionItems: aMin.hasOpenActionItems(),
                         sendActionItems: (sendActionItems) ? 'checked' : '',
-                        sendInformationItems: (sendInformationItems) ? 'checked' : ''
+                        sendInformationItems: (sendInformationItems) ? 'checked' : '',
+                        mailLanguage: msLanguage.name+'/'+msLanguage.nameNative+' ('+msLanguage.code+')'
                     },
                     i18n.__('Dialog.ConfirmFinalizeMinutes.button')
                 ).show();

--- a/imports/collections/meetingseries.schema.js
+++ b/imports/collections/meetingseries.schema.js
@@ -35,6 +35,7 @@ export const MeetingSeriesSchema = SchemaClass.create({
         availableLabels: {type: [LabelSchema], default: []},
         additionalResponsibles: {type: [String], default: []},
         isEditedBy: {type: String, optional: true},
-        isEditedDate: {type: Date, optional: true}
+        isEditedDate: {type: Date, optional: true},
+        mailLanguage: {type: String, optional: true}
     }
 });

--- a/imports/config/GlobalSettings.js
+++ b/imports/config/GlobalSettings.js
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { LdapSettings } from '/imports/config/LdapSettings';
 import _ from 'lodash';
+import { i18n } from 'meteor/universe:i18n';
 
 function getSetting(path, def = undefined) {
     return _.get(Meteor.settings, path, def);
@@ -108,6 +109,17 @@ export class GlobalSettings {
             if (! Meteor.settings.attachments.storagePath.match(/\/$/)) {
                 Meteor.settings.attachments.storagePath = Meteor.settings.attachments.storagePath + '/';
             }
+        }
+
+        Meteor.settings.public.defaultMeetingSeriesMailLanguage =
+            Meteor.settings.defaultMeetingSeriesMailLanguage
+                ? Meteor.settings.defaultMeetingSeriesMailLanguage
+                : 'en';
+        if (!i18n.getLanguages().includes(Meteor.settings.public.defaultMeetingSeriesMailLanguage)) {
+            console.log('WARNING: settings for defaultMeetingSeriesMailLanguage invalid: '+Meteor.settings.public.defaultMeetingSeriesMailLanguage);
+            console.log('         Fallback to: en');
+            Meteor.settings.defaultMeetingSeriesMailLanguage = 'en';
+            Meteor.settings.public.defaultMeetingSeriesMailLanguage = 'en';
         }
 
         LdapSettings.publish();
@@ -286,5 +298,9 @@ export class GlobalSettings {
 
     static getAttachmentsEnabled() {
         return  Meteor.settings.public.attachments.enabled;
+    }
+
+    static getDefaultMeetingSeriesMailLanguage() {
+        return Meteor.settings.public.defaultMeetingSeriesMailLanguage;
     }
 }

--- a/imports/documentGeneration.js
+++ b/imports/documentGeneration.js
@@ -5,6 +5,7 @@
  */
 
 import { Meteor } from 'meteor/meteor';
+import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 import { i18n } from 'meteor/universe:i18n';
 
 import { Minutes } from './minutes';

--- a/imports/helpers/i18n.js
+++ b/imports/helpers/i18n.js
@@ -14,6 +14,7 @@ const approvedLocales = {
     'de':       true,
     'de-fr':    true,
     'el':       true,
+    'fr':       true,
     'it':       true,
     'nl':       true,
     'pl':       true,

--- a/imports/helpers/i18n.js
+++ b/imports/helpers/i18n.js
@@ -3,22 +3,43 @@ import { i18n } from 'meteor/universe:i18n';
 import { T9n } from 'meteor/softwarerero:accounts-t9n';
 import './promisedMethods';
 
+// We translate the 4Minitz UI with the help of CrowdIn:
+// https://crowdin.com/project/4minitz
+// For each language we start with a machine translation of English base texts
+// These machine translations always need native speaker approval / corrections
+// Below we list
+//       ****>>> languages with >90% strings approved <<<<****
+// So we can mark all other languages in the UI as "W-I-P" / Help wanted
+const approvedLocales = {
+    'de':       true,
+    'de-fr':    true,
+    'el':       true,
+    'it':       true,
+    'nl':       true,
+    'pl':       true,
+    'zh-cn':    true,
+};
+
 // Only server can provide all available languages via server-side method
 Meteor.methods({
-    getAvailableLocales() {
+    getAvailableLocales: function () {
         // [{code: "el", name: "Greek", nameNative: "Ελληνικά"}, ...]
         return i18n.getLanguages().map(code => {
             if (code.toLowerCase() === 'de-li') {
+                const franconianCode = 'de-Fr';
                 return {
                     code: code,
-                    codeUI: 'de-Fr',
+                    codeUI: franconianCode,
+                    approved: !!approvedLocales[franconianCode.toLowerCase()],
                     name: 'German (Franconian)',
                     nameNative: 'Deutsch (Fränggisch)'
                 };
             }
+            console.log('>>>', code, !!approvedLocales[code.toLowerCase()]);
             return {
                 code: code,
                 codeUI: code,
+                approved: !!approvedLocales[code.toLowerCase()],
                 name: i18n.getLanguageName(code),
                 nameNative: i18n.getLanguageNativeName(code)[0].toUpperCase() + i18n.getLanguageNativeName(code).slice(1)
             };

--- a/imports/mail/FinalizeMailHandler.js
+++ b/imports/mail/FinalizeMailHandler.js
@@ -15,7 +15,11 @@ export class FinalizeMailHandler {
             throw new Meteor.Error('illegal-argument', 'sender address required');
         }
         if (typeof minute === 'string') {   // we may have an ID here.
-            minute = new Minutes(minute);
+            let minuteObj = new Minutes(minute);
+            if (!minuteObj) {
+                throw new Meteor.Error('illegal-argument', 'Unknown minute ID'+minute);
+            }
+            minute = minuteObj;
         }
 
         this._minute = minute;

--- a/imports/mail/SendAgendaMailHandler.js
+++ b/imports/mail/SendAgendaMailHandler.js
@@ -4,6 +4,7 @@ import { i18n } from 'meteor/universe:i18n';
 import { InfoItemsMailHandler } from './InfoItemsMailHandler';
 import { GlobalSettings } from '../config/GlobalSettings';
 import { DocumentGeneration } from '../documentGeneration';
+import {MeetingSeries} from '../meetingseries';
 
 export class SendAgendaMailHandler extends InfoItemsMailHandler {
 
@@ -18,8 +19,14 @@ export class SendAgendaMailHandler extends InfoItemsMailHandler {
     }
     
     _sendMail() {
-        super._sendMail(this._getEmailData());
-    }    
+        Meteor.defer(() => {    // we need .defer here, otherwise the setLocale won't be respected.
+            let ms = new MeetingSeries(this._meetingSeries._id);
+            let oldLoc = i18n.getLocale();
+            i18n.setLocale(ms.getMailLanguage());   // ask meeting series what language is preferred
+            super._sendMail(this._getEmailData());
+            i18n.setLocale(oldLoc);
+        });
+    }
 
     _getSubject() {
         return this._getSubjectPrefix() + ' (' + i18n.__('Minutes.agenda') + ')';

--- a/imports/mail/SendAgendaMailHandler.js
+++ b/imports/mail/SendAgendaMailHandler.js
@@ -19,12 +19,9 @@ export class SendAgendaMailHandler extends InfoItemsMailHandler {
     }
     
     _sendMail() {
-        Meteor.defer(() => {    // we need .defer here, otherwise the setLocale won't be respected.
-            let ms = new MeetingSeries(this._meetingSeries._id);
-            let oldLoc = i18n.getLocale();
-            i18n.setLocale(ms.getMailLanguage());   // ask meeting series what language is preferred
+        let ms = new MeetingSeries(this._meetingSeries._id);
+        i18n.runWithLocale(ms.getMailLanguage(), () => {
             super._sendMail(this._getEmailData());
-            i18n.setLocale(oldLoc);
         });
     }
 

--- a/imports/meetingseries.js
+++ b/imports/meetingseries.js
@@ -12,6 +12,7 @@ import './helpers/promisedMethods';
 import './collections/meetingseries_private';
 import moment from 'moment/moment';
 import {TopicsFinder} from './services/topicsFinder';
+import {GlobalSettings} from './config/GlobalSettings';
 
 export class MeetingSeries {
     constructor(source) {   // constructs obj from Mongo ID or Mongo document
@@ -351,5 +352,12 @@ export class MeetingSeries {
 
     findTopic(topicId) {
         return TopicsFinder.getTopicById(topicId, this._id);
+    }
+
+    getMailLanguage() {
+        if (this.mailLanguage) {
+            return this.mailLanguage;
+        }
+        return GlobalSettings.getDefaultMeetingSeriesMailLanguage();
     }
 }

--- a/imports/services/finalize-minutes/finalizer.js
+++ b/imports/services/finalize-minutes/finalizer.js
@@ -39,18 +39,14 @@ function sendFinalizationMail(minutes, sendActionItems, sendInfoItems) {
     }
 
     let emails = Meteor.user().emails;
-    Meteor.defer(() => { // server background tasks after successfully updated the minute doc
-        const senderEmail = (emails && emails.length > 0)
-            ? emails[0].address
-            : GlobalSettings.getDefaultEmailSenderAddress();
+    const senderEmail = (emails && emails.length > 0)
+        ? emails[0].address
+        : GlobalSettings.getDefaultEmailSenderAddress();
 
-        // i18n.setLocale(i18nLocale);
-        let ms = new MeetingSeries(minutes.parentMeetingSeriesID());
-        const oldLocale = i18n.getLocale();
-        i18n.setLocale(ms.getMailLanguage());
+    let ms = new MeetingSeries(minutes.parentMeetingSeriesID());
+    i18n.runWithLocale(ms.getMailLanguage(), () => {
         const finalizeMailHandler = new FinalizeMailHandler(minutes, senderEmail);
         finalizeMailHandler.sendMails(sendActionItems, sendInfoItems);
-        i18n.setLocale(oldLocale);
     });
 }
 
@@ -180,19 +176,12 @@ export class Finalizer {
         Meteor.call('workflow.finalizeMinute', minutesId, sendActionItems, sendInfoItems);
         // save protocol if enabled
         if (Meteor.settings.public.docGeneration.enabled) {
-            Meteor.defer(function () {  // we need .defer here, otherwise the setLocale won't be respected.
-                let min = new Minutes(minutesId);
-                let ms = new MeetingSeries(min.parentMeetingSeriesID());
-                let oldLoc = i18n.getLocale();
-                i18n.setLocale(ms.getMailLanguage());   // ask meeting series what language is preferred
-                Meteor.call('documentgeneration.createAndStoreFile', minutesId, (error) => {
-                    if (error) {
-                        error.reason = error.reason ? error.reason : error.error;
-                        onErrorCallback(error);
-                    }
+            Meteor.call('documentgeneration.createAndStoreFile', minutesId, (error) => {
+                if (error) {
+                    error.reason = error.reason ? error.reason : error.error;
+                    onErrorCallback(error);
+                }
 
-                });
-                i18n.setLocale(oldLoc);
             });
         }
     }

--- a/server/main.server.js
+++ b/server/main.server.js
@@ -149,5 +149,6 @@ Meteor.startup(() => {
             });
         }
     }
-});
 
+    console.log('*** Default language for meeting series eMails: '+ GlobalSettings.getDefaultMeetingSeriesMailLanguage());
+});

--- a/settings_sample.json
+++ b/settings_sample.json
@@ -55,7 +55,18 @@
     "//2.2": "Change name of site",
     "siteName": "4Minitz",
 
-    "//3": "below option configures if and how to send E-Mails",
+  "//2.3": ["defaultMeetingSeriesMailLanguage:",
+    "New meeting series will get this language for sent eMails (finalized meeting minutes, agenda, action items).",
+    "Additionally this language is used for long-term archive of meeting minutes via the 'docGeneration' feature",
+    "A moderator can overwrite this default language in the settings of the meeting series.",
+    "Rationale: As eMails of meeting minutes often go to more than one user,",
+    "these eMail's language might need to be a different one as the moderator's own UI language.",
+    "Attention! Make sure this is a supported 4Minitz language locale, like: en, zh-cn, zh-tw"
+    ],
+  "defaultMeetingSeriesMailLanguage": "en",
+
+
+  "//3": "below option configures if and how to send E-Mails",
     "email": {
         "//3.1": "Switch on/off E-Mail sending",
         "enableMailDelivery": false,

--- a/tests/unit/imports/GlobalSettings.test.js
+++ b/tests/unit/imports/GlobalSettings.test.js
@@ -20,10 +20,15 @@ const LdapSettings = {
     publish: sinon.stub()
 };
 
+let i18n = {
+    getLanguages: () => {return ['en'];}
+};
+
 const {
     GlobalSettings
     } = proxyquire('../../../imports/config/GlobalSettings', {
     'meteor/meteor': { Meteor, '@noCallThru': true},
+    'meteor/universe:i18n': { i18n, '@noCallThru': true},
     '/imports/config/LdapSettings': { LdapSettings, '@noCallThru': true}
 });
 

--- a/tests/unit/imports/services/finalize-minutes/finalizer.test.js
+++ b/tests/unit/imports/services/finalize-minutes/finalizer.test.js
@@ -16,10 +16,11 @@ let MeetingSeriesSchema = {
     findOne: sinon.stub()
 };
 
+let ms1 = {
+    getMailLanguage: () => {return 'en'; }
+};
+let MeetingSeries = sinon.stub().returns(ms1);
 let Minutes = sinon.stub();
-//let Minutes = {
-//    save: sinon.stub(),
-//};
 
 const Topics = sinon.stub();
 const check = sinon.stub();
@@ -85,6 +86,7 @@ const {
     'meteor/check': { check, '@noCallThru': true },
     '/imports/collections/minutes.schema': { MinutesSchema, '@noCallThru': true },
     '/imports/collections/meetingseries.schema': { MeetingSeriesSchema, '@noCallThru': true },
+    '/imports/meetingseries': { MeetingSeries, '@noCallThru': true },
     '/imports/minutes': { Minutes, '@noCallThru': true },
     '/imports/topic': { Topics, '@noCallThru': true },
     '/imports/userroles': { UserRoles, '@noCallThru': true },
@@ -374,13 +376,16 @@ describe('workflow.unfinalizeMinute', function () {
     });
 });
 
+
 describe('Finalizer', function () {
     let minutesId, minutes;
 
     beforeEach(function () {
         minutesId = 'AaBbCc02';
 
-        minutes = {};
+        minutes = {
+            parentMeetingSeriesID: sinon.stub().returns(12),
+        };
         Minutes.returns(minutes);
     });
 

--- a/tests/unit/imports/services/finalize-minutes/finalizer.test.js
+++ b/tests/unit/imports/services/finalize-minutes/finalizer.test.js
@@ -74,7 +74,10 @@ const User = {
 
 let i18n = {
     setLocale: sinon.stub(),
-    getLocale: sinon.stub()
+    getLocale: sinon.stub(),
+    runWithLocale: (locale, callback) => {
+        callback();
+    },
 };
 
 const {


### PR DESCRIPTION
Would solve #540 

Now a meeting series can remember the desired language for all generated documents (eMails & PDF/HTML docGeneration) during a meeting workflow: 

- eMails for agenda, action items, Topic/Info
- PDF/HTML docGeneration

A new parameter in settings.json `defaultMeetingSeriesMailLanguage` allows admin to specify the default language for all new created meeting series and for legacy (pre 4Minitz v2.0) meeting series. Moderator may override the admin default in the Meeting series settings dialog (Tab: Base Settings).

![grafik](https://user-images.githubusercontent.com/4393698/76707671-725bed00-66f1-11ea-9155-22fb652bb6f6.png)

![grafik](https://user-images.githubusercontent.com/4393698/76707682-8f90bb80-66f1-11ea-9673-4e55a62b10aa.png)
