### PR TITLE
Hotfix for #448: Subscribe to the topics collection from the minutesedit view

### DIFF
--- a/client/templates/minutes/minutesedit.js
+++ b/client/templates/minutes/minutesedit.js
@@ -162,6 +162,10 @@ Template.minutesedit.onCreated(function () {
             this.subscribe('meetingSeriesDetails', meetingSeriesId);
             this.subscribe('files.attachments.all', meetingSeriesId, _minutesID);        
             this.subscribe('files.protocols.all', meetingSeriesId, _minutesID);
+            // Workaround: We subscribe to the topics collection to allow creating new minutes
+            // from the minutesedit view, too.
+            // See https://github.com/4minitz/4minitz/issues/448#issuecomment-597498201 for details.
+            this.subscribe('topics', meetingSeriesId);
             
             this.minutesReady.set(this.subscriptionsReady());
         }


### PR DESCRIPTION
See #448 

When creating new minutes the topics collection is necessary on the client since
 the client prepares the topics for the new minutes.
So if the client cannot access the topics collection the new minutes comes with
 an empty topics array.

See https://github.com/4minitz/4minitz/issues/448#issuecomment-597498201

Maybe the better solution would be to migrate the topics preparation for new
 minutes to the server side.