### PR TITLE
Prepare topics for new minutes within meteor method to guarantee access to Topics Collection

### DIFF
--- a/client/templates/minutes/minutesedit.js
+++ b/client/templates/minutes/minutesedit.js
@@ -481,7 +481,10 @@ Template.minutesedit.events({
     'click #btnCreateNewMinutes': function(evt) {
         evt.preventDefault();
         let ms = new MeetingSeries(new Minutes(_minutesID).parentMeetingSeriesID());
-        const routeToNewMinutes = (newMinutesId) => FlowRouter.redirect('/minutesedit/' + newMinutesId);
+        const routeToNewMinutes = (newMinutesId) => {
+            Session.set('minutesedit.checkParent', false);
+            FlowRouter.redirect('/minutesedit/' + newMinutesId);
+        };
         const confirmationDialog = ConfirmationDialogFactory.makeSuccessDialogWithTemplate(
             () => ms.addNewMinutes(routeToNewMinutes, handleError),
             i18n.__('Dialog.ConfirmCreateNewMinutes.title'),

--- a/imports/collections/workflow_private.js
+++ b/imports/collections/workflow_private.js
@@ -74,7 +74,6 @@ Meteor.methods({
 
         let topics = [];
         // copy open topics from this meeting series & set isNew=false, isSkipped=false
-        console.log(`Parent MS id: ${parentMeetingSeries._id}`);
         const openTopics = TopicsFinder.allOpenTopicsOfMeetingSeries(parentMeetingSeries._id);
         console.log(openTopics);
         if (openTopics) {

--- a/imports/meetingseries.js
+++ b/imports/meetingseries.js
@@ -3,7 +3,6 @@ import { Random } from 'meteor/random';
 import { MeetingSeriesSchema } from './collections/meetingseries.schema';
 import { MinutesFinder } from '/imports/services/minutesFinder';
 import { Minutes } from './minutes';
-import { Topic } from './topic';
 import { UserRoles } from './userroles';
 import { formatDateISO8601 } from '/imports/helpers/date';
 import { subElementsHelper } from '/imports/helpers/subElements';
@@ -100,26 +99,9 @@ export class MeetingSeries {
         const globalNotePinned = lastMinutes && lastMinutes.globalNotePinned;
         let globalNote = (globalNotePinned) ? lastMinutes.globalNote : '';
 
-        let topics = [];
-
-        // copy open topics from this meeting series & set isNew=false, isSkipped=false
-        const openTopics = TopicsFinder.allOpenTopicsOfMeetingSeries(this._id);
-        if (openTopics) {
-            topics = openTopics;
-            topics.forEach((topicDoc) => {
-                let topic = new Topic(this, topicDoc);
-                topic.tailorTopic();
-                topic.invalidateIsNewFlag();
-                if (topic.isSkipped()) {
-                    topic.toggleSkip();
-                }
-            });
-        }
-
         let min = new Minutes({
             meetingSeries_id: this._id,
             date: formatDateISO8601(newMinutesDate),
-            topics: topics,
             visibleFor: this.visibleFor,             // freshly created minutes inherit visibility of their series
             informedUsers: this.informedUsers,       // freshly created minutes inherit informedUsers of their series
             globalNotePinned: globalNotePinned,


### PR DESCRIPTION
See #448

To prepare the topics for a new minutes access to the topics collection is required.
It is safer to do this preparation within a meteor methods since this will be executed
 on the server-side, too, so it is not necessary to ensure that the template executing
 the addMinutes workflow subscribed to the topics collection.

The `minutesedit.checkParent` session variable ensures that the check if the minutes is linked
 to its parent series will be done after a short timeout after the page was initialized.
So we reset it before creating new minutes.

Alternative to #545 